### PR TITLE
Add new GetSession command, add request IDs

### DIFF
--- a/citadel_workspace_lib/src/lib.rs
+++ b/citadel_workspace_lib/src/lib.rs
@@ -1,8 +1,8 @@
-use citadel_workspace_types::{InternalServicePayload, InternalServiceResponse};
+use citadel_workspace_types::{InternalServiceRequest, InternalServiceResponse};
 use tokio::net::TcpStream;
 use tokio_util::codec::{Framed, LengthDelimitedCodec};
 
-pub fn deserialize(message: &[u8]) -> Option<InternalServicePayload> {
+pub fn deserialize(message: &[u8]) -> Option<InternalServiceRequest> {
     bincode2::deserialize(message).ok()
 }
 

--- a/citadel_workspace_service/src/kernel/mod.rs
+++ b/citadel_workspace_service/src/kernel/mod.rs
@@ -5,7 +5,7 @@ use citadel_sdk::prelude::VirtualTargetType;
 use citadel_sdk::prelude::*;
 use citadel_workspace_lib::{deserialize, serialize_payload, wrap_tcp_conn};
 use citadel_workspace_types::{
-    Disconnected, InternalServicePayload, InternalServiceResponse, ServiceConnectionAccepted,
+    Disconnected, InternalServiceRequest, InternalServiceResponse, ServiceConnectionAccepted,
 };
 use futures::stream::{SplitSink, StreamExt};
 use futures::SinkExt;
@@ -107,7 +107,7 @@ impl NetKernel for CitadelWorkspaceService {
         let remote_for_closure = remote.clone();
         let listener = tokio::net::TcpListener::bind(self.bind_address).await?;
 
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<InternalServicePayload>();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<InternalServiceRequest>();
 
         let tcp_connection_map = &self.tcp_connection_map.clone();
         let listener_task = async move {
@@ -140,7 +140,7 @@ impl NetKernel for CitadelWorkspaceService {
             res1 = inbound_command_task => res1,
         };
 
-        citadel_logging::warn!(target: "citadel", "Shutting down service because a critical task finished. {res:?}");
+        warn!(target: "citadel", "Shutting down service because a critical task finished. {res:?}");
         remote_for_closure.shutdown().await?;
         res
     }
@@ -192,6 +192,7 @@ impl NetKernel for CitadelWorkspaceService {
                         let response = InternalServiceResponse::Disconnected(Disconnected {
                             cid: implicated_cid,
                             peer_cid: Some(peer_cid),
+                            request_id: None,
                         });
                         send_response_to_tcp_client(&self.tcp_connection_map, response, uuid).await;
                     }
@@ -210,7 +211,7 @@ impl NetKernel for CitadelWorkspaceService {
 }
 
 async fn send_response_to_tcp_client(
-    hash_map: &Arc<tokio::sync::Mutex<HashMap<Uuid, UnboundedSender<InternalServiceResponse>>>>,
+    hash_map: &Arc<Mutex<HashMap<Uuid, UnboundedSender<InternalServiceResponse>>>>,
     response: InternalServiceResponse,
     uuid: Uuid,
 ) {
@@ -243,7 +244,7 @@ async fn sink_send_payload(
 
 fn send_to_kernel(
     payload_to_send: &[u8],
-    sender: &UnboundedSender<InternalServicePayload>,
+    sender: &UnboundedSender<InternalServiceRequest>,
 ) -> Result<(), NetworkError> {
     if let Some(payload) = deserialize(payload_to_send) {
         sender.send(payload)?;
@@ -256,7 +257,7 @@ fn send_to_kernel(
 
 fn handle_connection(
     conn: TcpStream,
-    to_kernel: UnboundedSender<InternalServicePayload>,
+    to_kernel: UnboundedSender<InternalServiceRequest>,
     mut from_kernel: tokio::sync::mpsc::UnboundedReceiver<InternalServiceResponse>,
     conn_id: Uuid,
 ) {
@@ -268,6 +269,7 @@ fn handle_connection(
             let response =
                 InternalServiceResponse::ServiceConnectionAccepted(ServiceConnectionAccepted {
                     id: conn_id,
+                    request_id: None,
                 });
 
             sink_send_payload(&response, &mut sink).await;

--- a/citadel_workspace_service/src/kernel/mod.rs
+++ b/citadel_workspace_service/src/kernel/mod.rs
@@ -9,7 +9,7 @@ use citadel_workspace_types::{
 };
 use futures::stream::{SplitSink, StreamExt};
 use futures::SinkExt;
-use payload_handler::payload_handler;
+use request_handler::handle_request;
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -19,7 +19,7 @@ use tokio::sync::Mutex;
 use tokio_util::codec::{Framed, LengthDelimitedCodec};
 use uuid::Uuid;
 
-pub(crate) mod payload_handler;
+pub(crate) mod request_handler;
 
 pub struct CitadelWorkspaceService {
     pub remote: Option<NodeRemote>,
@@ -124,7 +124,7 @@ impl NetKernel for CitadelWorkspaceService {
 
         let inbound_command_task = async move {
             while let Some(command) = rx.recv().await {
-                payload_handler(
+                handle_request(
                     command,
                     &server_connection_map,
                     &mut remote,

--- a/citadel_workspace_service/src/kernel/payload_handler.rs
+++ b/citadel_workspace_service/src/kernel/payload_handler.rs
@@ -4,13 +4,13 @@ use citadel_logging::{error, info};
 use citadel_sdk::prefabs::ClientServerRemote;
 use citadel_sdk::prelude::*;
 use citadel_workspace_types::{
-    ConnectionFailure, DisconnectFailure, Disconnected, InternalServicePayload,
+    ConnectionFailure, DisconnectFailure, Disconnected, GetSessions, InternalServiceRequest,
     InternalServiceResponse, LocalDBClearAllKVFailure, LocalDBClearAllKVSuccess,
     LocalDBDeleteKVFailure, LocalDBDeleteKVSuccess, LocalDBGetAllKVFailure, LocalDBGetAllKVSuccess,
     LocalDBGetKVFailure, LocalDBGetKVSuccess, LocalDBSetKVFailure, LocalDBSetKVSuccess,
     MessageReceived, MessageSendError, MessageSent, PeerConnectFailure, PeerConnectSuccess,
     PeerDisconnectFailure, PeerDisconnectSuccess, PeerRegisterFailure, PeerRegisterSuccess,
-    SendFileFailure, SendFileSuccess,
+    PeerSessionInformation, SendFileFailure, SendFileSuccess, SessionInformation,
 };
 use futures::StreamExt;
 use std::collections::HashMap;
@@ -21,15 +21,47 @@ use tokio::sync::Mutex;
 use uuid::Uuid;
 #[async_recursion]
 pub async fn payload_handler(
-    command: InternalServicePayload,
+    command: InternalServiceRequest,
     server_connection_map: &Arc<Mutex<HashMap<u64, Connection>>>,
     remote: &mut NodeRemote,
-    tcp_connection_map: &Arc<
-        tokio::sync::Mutex<HashMap<Uuid, UnboundedSender<InternalServiceResponse>>>,
-    >,
+    tcp_connection_map: &Arc<Mutex<HashMap<Uuid, UnboundedSender<InternalServiceResponse>>>>,
 ) {
     match command {
-        InternalServicePayload::Connect {
+        // Return all the sessions for the given TCP connection
+        InternalServiceRequest::GetSessions { uuid, request_id } => {
+            let lock = server_connection_map.lock().await;
+            let mut sessions = Vec::new();
+            for (cid, connection) in lock.iter() {
+                if connection.associated_tcp_connection == uuid {
+                    let mut session = SessionInformation {
+                        cid: *cid,
+                        peer_connections: HashMap::new(),
+                    };
+                    for (peer_cid, conn) in connection.peers.iter() {
+                        session.peer_connections.insert(
+                            *peer_cid,
+                            PeerSessionInformation {
+                                cid: *cid,
+                                peer_cid: *peer_cid,
+                                peer_username: conn
+                                    .remote
+                                    .target_username()
+                                    .cloned()
+                                    .unwrap_or_default(),
+                            },
+                        );
+                    }
+                    sessions.push(session);
+                }
+            }
+
+            let response = InternalServiceResponse::GetSessions(GetSessions {
+                sessions,
+                request_id: Some(request_id),
+            });
+            send_response_to_tcp_client(tcp_connection_map, response, uuid).await;
+        }
+        InternalServiceRequest::Connect {
             uuid,
             username,
             password,
@@ -37,6 +69,7 @@ pub async fn payload_handler(
             udp_mode,
             keep_alive_timeout,
             session_security_settings,
+            request_id,
         } => {
             match remote
                 .connect(
@@ -63,7 +96,10 @@ pub async fn payload_handler(
                     let hm_for_conn = tcp_connection_map.clone();
 
                     let response = InternalServiceResponse::ConnectSuccess(
-                        citadel_workspace_types::ConnectSuccess { cid },
+                        citadel_workspace_types::ConnectSuccess {
+                            cid,
+                            request_id: Some(request_id),
+                        },
                     );
 
                     send_response_to_tcp_client(tcp_connection_map, response, uuid).await;
@@ -75,6 +111,7 @@ pub async fn payload_handler(
                                     message: message.into_buffer(),
                                     cid,
                                     peer_cid: 0,
+                                    request_id: Some(request_id),
                                 });
                             match hm_for_conn.lock().await.get(&uuid) {
                                 Some(entry) => match entry.send(message) {
@@ -93,12 +130,13 @@ pub async fn payload_handler(
                 Err(err) => {
                     let response = InternalServiceResponse::ConnectionFailure(ConnectionFailure {
                         message: err.into_string(),
+                        request_id: Some(request_id),
                     });
                     send_response_to_tcp_client(tcp_connection_map, response, uuid).await;
                 }
             };
         }
-        InternalServicePayload::Register {
+        InternalServiceRequest::Register {
             uuid,
             server_addr,
             full_name,
@@ -106,6 +144,7 @@ pub async fn payload_handler(
             proposed_password,
             connect_after_register,
             default_security_settings,
+            request_id,
         } => {
             info!(target: "citadel", "About to connect to server {server_addr:?} for user {username}");
             match remote
@@ -118,52 +157,55 @@ pub async fn payload_handler(
                 )
                 .await
             {
-                Ok(_res) => {
-                    match connect_after_register {
-                        false => {
-                            // TODO: add trace ID to ensure uniqueness of request
-                            let response = InternalServiceResponse::RegisterSuccess(
-                                citadel_workspace_types::RegisterSuccess { id: uuid },
-                            );
-                            send_response_to_tcp_client(tcp_connection_map, response, uuid).await
-                        }
-                        true => {
-                            let connect_command = InternalServicePayload::Connect {
-                                uuid,
-                                username,
-                                password: proposed_password,
-                                keep_alive_timeout: None,
-                                udp_mode: Default::default(),
-                                connect_mode: Default::default(),
-                                session_security_settings: default_security_settings,
-                            };
-
-                            payload_handler(
-                                connect_command,
-                                server_connection_map,
-                                remote,
-                                tcp_connection_map,
-                            )
-                            .await
-                        }
+                Ok(_res) => match connect_after_register {
+                    false => {
+                        let response = InternalServiceResponse::RegisterSuccess(
+                            citadel_workspace_types::RegisterSuccess {
+                                id: uuid,
+                                request_id: Some(request_id),
+                            },
+                        );
+                        send_response_to_tcp_client(tcp_connection_map, response, uuid).await
                     }
-                }
+                    true => {
+                        let connect_command = InternalServiceRequest::Connect {
+                            uuid,
+                            username,
+                            password: proposed_password,
+                            keep_alive_timeout: None,
+                            udp_mode: Default::default(),
+                            connect_mode: Default::default(),
+                            session_security_settings: default_security_settings,
+                            request_id,
+                        };
+
+                        payload_handler(
+                            connect_command,
+                            server_connection_map,
+                            remote,
+                            tcp_connection_map,
+                        )
+                        .await
+                    }
+                },
                 Err(err) => {
                     let response = InternalServiceResponse::RegisterFailure(
                         citadel_workspace_types::RegisterFailure {
                             message: err.into_string(),
+                            request_id: Some(request_id),
                         },
                     );
                     send_response_to_tcp_client(tcp_connection_map, response, uuid).await
                 }
             };
         }
-        InternalServicePayload::Message {
+        InternalServiceRequest::Message {
             uuid,
             message,
             cid,
             peer_cid,
             security_level,
+            request_id,
         } => {
             match server_connection_map.lock().await.get_mut(&cid) {
                 Some(conn) => {
@@ -181,6 +223,7 @@ pub async fn payload_handler(
                                 InternalServiceResponse::MessageSendError(MessageSendError {
                                     cid,
                                     message: format!("Connection for {cid} not found"),
+                                    request_id: Some(request_id),
                                 }),
                                 uuid,
                             )
@@ -195,8 +238,11 @@ pub async fn payload_handler(
                             .unwrap();
                     }
 
-                    let response =
-                        InternalServiceResponse::MessageSent(MessageSent { cid, peer_cid });
+                    let response = InternalServiceResponse::MessageSent(MessageSent {
+                        cid,
+                        peer_cid,
+                        request_id: Some(request_id),
+                    });
                     send_response_to_tcp_client(tcp_connection_map, response, uuid).await;
                     info!(target: "citadel", "Into the message handler command send")
                 }
@@ -207,6 +253,7 @@ pub async fn payload_handler(
                         InternalServiceResponse::MessageSendError(MessageSendError {
                             cid,
                             message: format!("Connection for {cid} not found"),
+                            request_id: Some(request_id),
                         }),
                         uuid,
                     )
@@ -215,7 +262,11 @@ pub async fn payload_handler(
             };
         }
 
-        InternalServicePayload::Disconnect { cid, uuid } => {
+        InternalServiceRequest::Disconnect {
+            cid,
+            uuid,
+            request_id,
+        } => {
             let request = NodeRequest::DisconnectFromHypernode(DisconnectFromHypernode {
                 implicated_cid: cid,
                 v_conn_type: VirtualTargetType::LocalGroupServer {
@@ -228,6 +279,7 @@ pub async fn payload_handler(
                     let disconnect_success = InternalServiceResponse::Disconnected(Disconnected {
                         cid,
                         peer_cid: None,
+                        request_id: Some(request_id),
                     });
                     send_response_to_tcp_client(tcp_connection_map, disconnect_success, uuid).await;
                     info!(target: "citadel", "Disconnected {res:?}")
@@ -239,18 +291,20 @@ pub async fn payload_handler(
                         InternalServiceResponse::DisconnectFailure(DisconnectFailure {
                             cid,
                             message: error_message,
+                            request_id: Some(request_id),
                         });
                     send_response_to_tcp_client(tcp_connection_map, disconnect_failure, uuid).await;
                 }
             };
         }
 
-        InternalServicePayload::SendFile {
+        InternalServiceRequest::SendFile {
             uuid,
             source,
             cid,
             chunk_size,
             transfer_type,
+            request_id,
         } => {
             let client_to_server_remote = ClientServerRemote::new(
                 VirtualTargetType::LocalGroupServer {
@@ -265,7 +319,10 @@ pub async fn payload_handler(
                 Ok(_) => {
                     send_response_to_tcp_client(
                         tcp_connection_map,
-                        InternalServiceResponse::SendFileSuccess(SendFileSuccess { cid }),
+                        InternalServiceResponse::SendFileSuccess(SendFileSuccess {
+                            cid,
+                            request_id: Some(request_id),
+                        }),
                         uuid,
                     )
                     .await;
@@ -277,6 +334,7 @@ pub async fn payload_handler(
                         InternalServiceResponse::SendFileFailure(SendFileFailure {
                             cid,
                             message: err.into_string(),
+                            request_id: Some(request_id),
                         }),
                         uuid,
                     )
@@ -285,12 +343,13 @@ pub async fn payload_handler(
             }
         }
 
-        InternalServicePayload::DownloadFile {
+        InternalServiceRequest::DownloadFile {
             virtual_path: _,
             transfer_security_level: _,
             delete_on_pull: _,
             cid: _,
             uuid: _,
+            request_id: _,
         } => {
             // let mut client_to_server_remote = ClientServerRemote::new(VirtualTargetType::LocalGroupServer { implicated_cid: cid }, remote.clone());
             // match client_to_server_remote.(virtual_path, transfer_security_level, delete_on_pull).await {
@@ -303,10 +362,11 @@ pub async fn payload_handler(
             // }
         }
 
-        InternalServicePayload::StartGroup {
+        InternalServiceRequest::StartGroup {
             initial_users_to_invite,
             cid,
             uuid: _uuid,
+            request_id: _,
         } => {
             let client_to_server_remote = ClientServerRemote::new(
                 VirtualTargetType::LocalGroupServer {
@@ -324,11 +384,12 @@ pub async fn payload_handler(
             }
         }
 
-        InternalServicePayload::PeerRegister {
+        InternalServiceRequest::PeerRegister {
             uuid,
             cid,
             peer_id: peer_username,
             connect_after_register,
+            request_id,
         } => {
             let client_to_server_remote = ClientServerRemote::new(
                 VirtualTargetType::LocalGroupServer {
@@ -345,6 +406,12 @@ pub async fn payload_handler(
                     match symmetric_identifier_handle_ref.register_to_peer().await {
                         Ok(_peer_register_success) => {
                             let account_manager = symmetric_identifier_handle_ref.account_manager();
+                            let this_username = account_manager
+                                .get_username_by_cid(cid)
+                                .await
+                                .ok()
+                                .flatten()
+                                .unwrap_or_default();
                             if let Ok(target_information) = account_manager
                                 .find_target_information(cid, peer_username.clone())
                                 .await
@@ -352,14 +419,18 @@ pub async fn payload_handler(
                                 let (peer_cid, mutual_peer) = target_information.unwrap();
                                 match connect_after_register {
                                     true => {
-                                        let connect_command = InternalServicePayload::PeerConnect {
+                                        let connect_command = InternalServiceRequest::PeerConnect {
                                             uuid,
                                             cid,
-                                            username: mutual_peer.username.unwrap(),
+                                            username: this_username.clone(),
                                             peer_cid,
-                                            peer_username: String::from("peer.a"),
+                                            peer_username: mutual_peer
+                                                .username
+                                                .clone()
+                                                .unwrap_or_default(),
                                             udp_mode: Default::default(),
                                             session_security_settings: Default::default(),
+                                            request_id,
                                         };
 
                                         payload_handler(
@@ -378,7 +449,11 @@ pub async fn payload_handler(
                                                 PeerRegisterSuccess {
                                                     cid,
                                                     peer_cid,
-                                                    username: mutual_peer.username.unwrap(),
+                                                    peer_username: mutual_peer
+                                                        .username
+                                                        .clone()
+                                                        .unwrap_or_default(),
+                                                    request_id: Some(request_id),
                                                 },
                                             ),
                                             uuid,
@@ -395,6 +470,7 @@ pub async fn payload_handler(
                                 InternalServiceResponse::PeerRegisterFailure(PeerRegisterFailure {
                                     cid,
                                     message: err.into_string(),
+                                    request_id: Some(request_id),
                                 }),
                                 uuid,
                             )
@@ -409,6 +485,7 @@ pub async fn payload_handler(
                         InternalServiceResponse::PeerRegisterFailure(PeerRegisterFailure {
                             cid,
                             message: err.into_string(),
+                            request_id: Some(request_id),
                         }),
                         uuid,
                     )
@@ -417,7 +494,7 @@ pub async fn payload_handler(
             }
         }
 
-        InternalServicePayload::PeerConnect {
+        InternalServiceRequest::PeerConnect {
             uuid,
             cid,
             username,
@@ -425,6 +502,7 @@ pub async fn payload_handler(
             peer_username,
             udp_mode,
             session_security_settings,
+            request_id,
         } => {
             // TODO: check to see if peer is already in the hashmap
             let client_to_server_remote = ClientServerRemote::new(
@@ -464,6 +542,7 @@ pub async fn payload_handler(
                                 tcp_connection_map,
                                 InternalServiceResponse::PeerConnectSuccess(PeerConnectSuccess {
                                     cid,
+                                    request_id: Some(request_id),
                                 }),
                                 uuid,
                             )
@@ -475,6 +554,7 @@ pub async fn payload_handler(
                                             message: message.into_buffer(),
                                             cid: connection_cid,
                                             peer_cid,
+                                            request_id: Some(request_id),
                                         });
                                     match hm_for_conn.lock().await.get(&uuid) {
                                         Some(entry) => match entry.send(message) {
@@ -500,6 +580,7 @@ pub async fn payload_handler(
                                 InternalServiceResponse::PeerConnectFailure(PeerConnectFailure {
                                     cid,
                                     message: err.into_string(),
+                                    request_id: Some(request_id),
                                 }),
                                 uuid,
                             )
@@ -514,6 +595,7 @@ pub async fn payload_handler(
                         InternalServiceResponse::PeerConnectFailure(PeerConnectFailure {
                             cid,
                             message: err.into_string(),
+                            request_id: Some(request_id),
                         }),
                         uuid,
                     )
@@ -521,10 +603,11 @@ pub async fn payload_handler(
                 }
             }
         }
-        InternalServicePayload::PeerDisconnect {
+        InternalServiceRequest::PeerDisconnect {
             uuid,
             cid,
             peer_cid,
+            request_id,
         } => {
             let request = NodeRequest::PeerCommand(PeerCommand {
                 implicated_cid: cid,
@@ -544,6 +627,7 @@ pub async fn payload_handler(
                         InternalServiceResponse::PeerDisconnectFailure(PeerDisconnectFailure {
                             cid,
                             message: "Server connection not found".to_string(),
+                            request_id: Some(request_id),
                         }),
                         uuid,
                     )
@@ -558,7 +642,10 @@ pub async fn payload_handler(
                             conn.clear_peer_connection(peer_cid);
                             let peer_disconnect_success =
                                 InternalServiceResponse::PeerDisconnectSuccess(
-                                    PeerDisconnectSuccess { cid, ticket: 0 },
+                                    PeerDisconnectSuccess {
+                                        cid,
+                                        request_id: Some(request_id),
+                                    },
                                 );
                             send_response_to_tcp_client(
                                 tcp_connection_map,
@@ -576,6 +663,7 @@ pub async fn payload_handler(
                                     PeerDisconnectFailure {
                                         cid,
                                         message: error_message,
+                                        request_id: Some(request_id),
                                     },
                                 );
                             send_response_to_tcp_client(
@@ -589,11 +677,12 @@ pub async fn payload_handler(
                 },
             }
         }
-        InternalServicePayload::LocalDBGetKV {
+        InternalServiceRequest::LocalDBGetKV {
             uuid,
             cid,
             peer_cid,
             key,
+            request_id,
         } => match server_connection_map.lock().await.get_mut(&cid) {
             None => {
                 send_response_to_tcp_client(
@@ -602,6 +691,7 @@ pub async fn payload_handler(
                         cid,
                         peer_cid,
                         message: "Server connection not found".to_string(),
+                        request_id: Some(request_id),
                     }),
                     uuid,
                 )
@@ -617,6 +707,7 @@ pub async fn payload_handler(
                             cid,
                             Some(peer_cid),
                             key,
+                            Some(request_id),
                         )
                         .await;
                     } else {
@@ -626,6 +717,7 @@ pub async fn payload_handler(
                                 cid,
                                 peer_cid: Some(peer_cid),
                                 message: "Peer connection not found".to_string(),
+                                request_id: Some(request_id),
                             }),
                             uuid,
                         )
@@ -639,17 +731,19 @@ pub async fn payload_handler(
                         cid,
                         peer_cid,
                         key,
+                        Some(request_id),
                     )
                     .await;
                 }
             }
         },
-        InternalServicePayload::LocalDBSetKV {
+        InternalServiceRequest::LocalDBSetKV {
             uuid,
             cid,
             peer_cid,
             key,
             value,
+            request_id,
         } => match server_connection_map.lock().await.get_mut(&cid) {
             None => {
                 send_response_to_tcp_client(
@@ -658,6 +752,7 @@ pub async fn payload_handler(
                         cid,
                         peer_cid,
                         message: "Server connection not found".to_string(),
+                        request_id: Some(request_id),
                     }),
                     uuid,
                 )
@@ -674,6 +769,7 @@ pub async fn payload_handler(
                             Some(peer_cid),
                             key,
                             value,
+                            Some(request_id),
                         )
                         .await;
                     } else {
@@ -683,6 +779,7 @@ pub async fn payload_handler(
                                 cid,
                                 peer_cid: Some(peer_cid),
                                 message: "Peer connection not found".to_string(),
+                                request_id: Some(request_id),
                             }),
                             uuid,
                         )
@@ -697,16 +794,18 @@ pub async fn payload_handler(
                         peer_cid,
                         key,
                         value,
+                        Some(request_id),
                     )
                     .await;
                 }
             }
         },
-        InternalServicePayload::LocalDBDeleteKV {
+        InternalServiceRequest::LocalDBDeleteKV {
             uuid,
             cid,
             peer_cid,
             key,
+            request_id,
         } => match server_connection_map.lock().await.get_mut(&cid) {
             None => {
                 send_response_to_tcp_client(
@@ -715,6 +814,7 @@ pub async fn payload_handler(
                         cid,
                         peer_cid,
                         message: "Server connection not found".to_string(),
+                        request_id: Some(request_id),
                     }),
                     uuid,
                 )
@@ -730,6 +830,7 @@ pub async fn payload_handler(
                             cid,
                             Some(peer_cid),
                             key,
+                            Some(request_id),
                         )
                         .await;
                     } else {
@@ -740,6 +841,7 @@ pub async fn payload_handler(
                                     cid,
                                     peer_cid: Some(peer_cid),
                                     message: "Peer connection not found".to_string(),
+                                    request_id: Some(request_id),
                                 },
                             ),
                             uuid,
@@ -754,15 +856,17 @@ pub async fn payload_handler(
                         cid,
                         peer_cid,
                         key,
+                        Some(request_id),
                     )
                     .await;
                 }
             }
         },
-        InternalServicePayload::LocalDBGetAllKV {
+        InternalServiceRequest::LocalDBGetAllKV {
             uuid,
             cid,
             peer_cid,
+            request_id,
         } => match server_connection_map.lock().await.get_mut(&cid) {
             None => {
                 send_response_to_tcp_client(
@@ -771,6 +875,7 @@ pub async fn payload_handler(
                         cid,
                         peer_cid,
                         message: "Server connection not found".to_string(),
+                        request_id: Some(request_id),
                     }),
                     uuid,
                 )
@@ -785,6 +890,7 @@ pub async fn payload_handler(
                             uuid,
                             cid,
                             Some(peer_cid),
+                            Some(request_id),
                         )
                         .await;
                     } else {
@@ -795,6 +901,7 @@ pub async fn payload_handler(
                                     cid,
                                     peer_cid: Some(peer_cid),
                                     message: "Peer connection not found".to_string(),
+                                    request_id: Some(request_id),
                                 },
                             ),
                             uuid,
@@ -808,15 +915,17 @@ pub async fn payload_handler(
                         uuid,
                         cid,
                         peer_cid,
+                        Some(request_id),
                     )
                     .await;
                 }
             }
         },
-        InternalServicePayload::LocalDBClearAllKV {
+        InternalServiceRequest::LocalDBClearAllKV {
             uuid,
             cid,
             peer_cid,
+            request_id,
         } => match server_connection_map.lock().await.get_mut(&cid) {
             None => {
                 send_response_to_tcp_client(
@@ -825,6 +934,7 @@ pub async fn payload_handler(
                         cid,
                         peer_cid,
                         message: "Server connection not found".to_string(),
+                        request_id: Some(request_id),
                     }),
                     uuid,
                 )
@@ -839,6 +949,7 @@ pub async fn payload_handler(
                             uuid,
                             cid,
                             Some(peer_cid),
+                            Some(request_id),
                         )
                         .await;
                     } else {
@@ -849,6 +960,7 @@ pub async fn payload_handler(
                                     cid,
                                     peer_cid: Some(peer_cid),
                                     message: "Peer connection not found".to_string(),
+                                    request_id: Some(request_id),
                                 },
                             ),
                             uuid,
@@ -862,6 +974,7 @@ pub async fn payload_handler(
                         uuid,
                         cid,
                         peer_cid,
+                        Some(request_id),
                     )
                     .await;
                 }
@@ -877,6 +990,7 @@ async fn backend_handler_get(
     cid: u64,
     peer_cid: Option<u64>,
     key: String,
+    request_id: Option<Uuid>,
 ) {
     match remote.get(&key).await {
         Ok(value) => {
@@ -888,6 +1002,7 @@ async fn backend_handler_get(
                         peer_cid,
                         key,
                         value,
+                        request_id,
                     }),
                     uuid,
                 )
@@ -899,6 +1014,7 @@ async fn backend_handler_get(
                         cid,
                         peer_cid,
                         message: "Key not found".to_string(),
+                        request_id,
                     }),
                     uuid,
                 )
@@ -912,6 +1028,7 @@ async fn backend_handler_get(
                     cid,
                     peer_cid,
                     message: err.into_string(),
+                    request_id,
                 }),
                 uuid,
             )
@@ -921,6 +1038,7 @@ async fn backend_handler_get(
 }
 
 // backend_handler_set
+#[allow(clippy::too_many_arguments)]
 async fn backend_handler_set(
     remote: &impl BackendHandler,
     tcp_connection_map: &Arc<Mutex<HashMap<Uuid, UnboundedSender<InternalServiceResponse>>>>,
@@ -929,6 +1047,7 @@ async fn backend_handler_set(
     peer_cid: Option<u64>,
     key: String,
     value: Vec<u8>,
+    request_id: Option<Uuid>,
 ) {
     match remote.set(&key, value).await {
         Ok(_) => {
@@ -938,6 +1057,7 @@ async fn backend_handler_set(
                     cid,
                     peer_cid,
                     key,
+                    request_id,
                 }),
                 uuid,
             )
@@ -950,6 +1070,7 @@ async fn backend_handler_set(
                     cid,
                     peer_cid,
                     message: err.into_string(),
+                    request_id,
                 }),
                 uuid,
             )
@@ -966,6 +1087,7 @@ async fn backend_handler_delete(
     cid: u64,
     peer_cid: Option<u64>,
     key: String,
+    request_id: Option<Uuid>,
 ) {
     match remote.remove(&key).await {
         Ok(_) => {
@@ -975,6 +1097,7 @@ async fn backend_handler_delete(
                     cid,
                     peer_cid,
                     key,
+                    request_id,
                 }),
                 uuid,
             )
@@ -987,6 +1110,7 @@ async fn backend_handler_delete(
                     cid,
                     peer_cid,
                     message: err.into_string(),
+                    request_id,
                 }),
                 uuid,
             )
@@ -1002,6 +1126,7 @@ async fn backend_handler_get_all(
     uuid: Uuid,
     cid: u64,
     peer_cid: Option<u64>,
+    request_id: Option<Uuid>,
 ) {
     match remote.get_all().await {
         Ok(map) => {
@@ -1011,6 +1136,7 @@ async fn backend_handler_get_all(
                     cid,
                     peer_cid,
                     map,
+                    request_id,
                 }),
                 uuid,
             )
@@ -1023,6 +1149,7 @@ async fn backend_handler_get_all(
                     cid,
                     peer_cid,
                     message: err.into_string(),
+                    request_id,
                 }),
                 uuid,
             )
@@ -1038,6 +1165,7 @@ async fn backend_handler_clear_all(
     uuid: Uuid,
     cid: u64,
     peer_cid: Option<u64>,
+    request_id: Option<Uuid>,
 ) {
     match remote.remove_all().await {
         Ok(_) => {
@@ -1046,6 +1174,7 @@ async fn backend_handler_clear_all(
                 InternalServiceResponse::LocalDBClearAllKVSuccess(LocalDBClearAllKVSuccess {
                     cid,
                     peer_cid,
+                    request_id,
                 }),
                 uuid,
             )
@@ -1058,6 +1187,7 @@ async fn backend_handler_clear_all(
                     cid,
                     peer_cid,
                     message: err.into_string(),
+                    request_id,
                 }),
                 uuid,
             )

--- a/citadel_workspace_service/src/kernel/request_handler.rs
+++ b/citadel_workspace_service/src/kernel/request_handler.rs
@@ -20,7 +20,7 @@ use tokio::sync::Mutex;
 
 use uuid::Uuid;
 #[async_recursion]
-pub async fn payload_handler(
+pub async fn handle_request(
     command: InternalServiceRequest,
     server_connection_map: &Arc<Mutex<HashMap<u64, Connection>>>,
     remote: &mut NodeRemote,
@@ -179,7 +179,7 @@ pub async fn payload_handler(
                             request_id,
                         };
 
-                        payload_handler(
+                        handle_request(
                             connect_command,
                             server_connection_map,
                             remote,
@@ -433,7 +433,7 @@ pub async fn payload_handler(
                                             request_id,
                                         };
 
-                                        payload_handler(
+                                        handle_request(
                                             connect_command,
                                             server_connection_map,
                                             remote,

--- a/citadel_workspace_service/tests/service.rs
+++ b/citadel_workspace_service/tests/service.rs
@@ -6,7 +6,7 @@ mod tests {
     use citadel_workspace_lib::wrap_tcp_conn;
     use citadel_workspace_service::kernel::CitadelWorkspaceService;
     use citadel_workspace_types::{
-        InternalServicePayload, InternalServiceResponse, MessageReceived, MessageSent,
+        InternalServiceRequest, InternalServiceResponse, MessageReceived, MessageSent,
         PeerConnectSuccess, PeerRegisterSuccess, ServiceConnectionAccepted,
     };
     use core::panic;
@@ -44,7 +44,7 @@ mod tests {
 
     async fn send(
         sink: &mut SplitSink<Framed<TcpStream, LengthDelimitedCodec>, Bytes>,
-        command: InternalServicePayload,
+        command: InternalServiceRequest,
     ) -> Result<(), Box<dyn Error>> {
         let command = bincode2::serialize(&command)?;
         sink.send(command.into()).await?;
@@ -86,7 +86,11 @@ mod tests {
         )
         .await
         .unwrap();
-        let disconnect_command = InternalServicePayload::Disconnect { uuid, cid };
+        let disconnect_command = InternalServiceRequest::Disconnect {
+            uuid,
+            cid,
+            request_id: Uuid::new_v4(),
+        };
         to_service.send(disconnect_command).unwrap();
         let disconnect_response = from_service.recv().await.unwrap();
 
@@ -110,7 +114,7 @@ mod tests {
         password: S,
     ) -> Result<
         (
-            UnboundedSender<InternalServicePayload>,
+            UnboundedSender<InternalServiceRequest>,
             UnboundedReceiver<InternalServiceResponse>,
             Uuid,
             u64,
@@ -136,9 +140,10 @@ mod tests {
 
         if let InternalServiceResponse::ServiceConnectionAccepted(ServiceConnectionAccepted {
             id,
+            request_id: _,
         }) = greeter_packet
         {
-            let register_command = InternalServicePayload::Register {
+            let register_command = InternalServiceRequest::Register {
                 uuid: id,
                 server_addr,
                 full_name,
@@ -146,17 +151,18 @@ mod tests {
                 proposed_password: password.clone(),
                 default_security_settings: Default::default(),
                 connect_after_register: false,
+                request_id: Uuid::new_v4(),
             };
             send(&mut sink, register_command).await?;
 
             let second_packet = stream.next().await.unwrap()?;
             let response_packet: InternalServiceResponse = bincode2::deserialize(&second_packet)?;
             if let InternalServiceResponse::RegisterSuccess(
-                citadel_workspace_types::RegisterSuccess { id },
+                citadel_workspace_types::RegisterSuccess { id, request_id: _ },
             ) = response_packet
             {
                 // now, connect to the server
-                let command = InternalServicePayload::Connect {
+                let command = InternalServiceRequest::Connect {
                     username,
                     password,
                     connect_mode: Default::default(),
@@ -164,6 +170,7 @@ mod tests {
                     keep_alive_timeout: None,
                     uuid: id,
                     session_security_settings: Default::default(),
+                    request_id: Uuid::new_v4(),
                 };
 
                 send(&mut sink, command).await?;
@@ -171,7 +178,7 @@ mod tests {
                 let next_packet = stream.next().await.unwrap()?;
                 let response_packet: InternalServiceResponse = bincode2::deserialize(&next_packet)?;
                 if let InternalServiceResponse::ConnectSuccess(
-                    citadel_workspace_types::ConnectSuccess { cid },
+                    citadel_workspace_types::ConnectSuccess { cid, request_id: _ },
                 ) = response_packet
                 {
                     let (to_service, from_service) = tokio::sync::mpsc::unbounded_channel();
@@ -263,12 +270,13 @@ mod tests {
         .unwrap();
 
         let serialized_message = bincode2::serialize("Message Test").unwrap();
-        let message_command = InternalServicePayload::Message {
+        let message_command = InternalServiceRequest::Message {
             uuid,
             message: serialized_message,
             cid,
             peer_cid: None,
             security_level: SecurityLevel::Standard,
+            request_id: Uuid::new_v4(),
         };
         to_service.send(message_command).unwrap();
         let deserialized_message_response = from_service.recv().await.unwrap();
@@ -283,6 +291,7 @@ mod tests {
                 message,
                 cid,
                 peer_cid: _,
+                request_id: _,
             }) = deserialized_message_response
             {
                 println!("{message:?}");
@@ -295,7 +304,11 @@ mod tests {
             panic!("Message sending failed");
         }
 
-        let disconnect_command = InternalServicePayload::Disconnect { uuid, cid };
+        let disconnect_command = InternalServiceRequest::Disconnect {
+            uuid,
+            cid,
+            request_id: Uuid::new_v4(),
+        };
         to_service.send(disconnect_command).unwrap();
         let disconnect_response = from_service.recv().await.unwrap();
 
@@ -360,9 +373,10 @@ mod tests {
 
         if let InternalServiceResponse::ServiceConnectionAccepted(ServiceConnectionAccepted {
             id,
+            request_id: _,
         }) = greeter_packet
         {
-            let register_command = InternalServicePayload::Register {
+            let register_command = InternalServiceRequest::Register {
                 uuid: id,
                 server_addr: server_bind_address,
                 full_name: String::from("John"),
@@ -370,6 +384,7 @@ mod tests {
                 proposed_password: String::from("test12345").into_bytes().into(),
                 default_security_settings: Default::default(),
                 connect_after_register: true,
+                request_id: Uuid::new_v4(),
             };
             send(&mut sink, register_command).await?;
 
@@ -377,7 +392,10 @@ mod tests {
             let response_packet: InternalServiceResponse = bincode2::deserialize(&second_packet)?;
 
             if let InternalServiceResponse::ConnectSuccess(
-                citadel_workspace_types::ConnectSuccess { cid: _ },
+                citadel_workspace_types::ConnectSuccess {
+                    cid: _,
+                    request_id: _,
+                },
             ) = response_packet
             {
                 Ok(())
@@ -390,9 +408,9 @@ mod tests {
     }
 
     type PeerReturnHandle = (
-        UnboundedSender<InternalServicePayload>,
+        UnboundedSender<InternalServiceRequest>,
         UnboundedReceiver<InternalServiceResponse>,
-        UnboundedSender<InternalServicePayload>,
+        UnboundedSender<InternalServiceRequest>,
         UnboundedReceiver<InternalServiceResponse>,
         Uuid,
         Uuid,
@@ -458,20 +476,22 @@ mod tests {
         // now, both peers are connected and registered to the central server. Now, we
         // need to have them peer-register to each other
         to_service_a
-            .send(InternalServicePayload::PeerRegister {
+            .send(InternalServiceRequest::PeerRegister {
                 uuid: uuid_a,
                 cid: cid_a,
                 peer_id: cid_b.into(),
                 connect_after_register: false,
+                request_id: Uuid::new_v4(),
             })
             .unwrap();
 
         to_service_b
-            .send(InternalServicePayload::PeerRegister {
+            .send(InternalServiceRequest::PeerRegister {
                 uuid: uuid_b,
                 cid: cid_b,
                 peer_id: cid_a.into(),
                 connect_after_register: false,
+                request_id: Uuid::new_v4(),
             })
             .unwrap();
 
@@ -481,7 +501,8 @@ mod tests {
             InternalServiceResponse::PeerRegisterSuccess(PeerRegisterSuccess {
                 cid,
                 peer_cid,
-                username,
+                peer_username: username,
+                request_id: _,
             }) => {
                 assert_eq!(cid, cid_b);
                 assert_eq!(peer_cid, cid_b);
@@ -497,7 +518,8 @@ mod tests {
             InternalServiceResponse::PeerRegisterSuccess(PeerRegisterSuccess {
                 cid,
                 peer_cid,
-                username,
+                peer_username: username,
+                request_id: _,
             }) => {
                 assert_eq!(cid, cid_a);
                 assert_eq!(peer_cid, cid_a);
@@ -509,7 +531,7 @@ mod tests {
         }
 
         to_service_a
-            .send(InternalServicePayload::PeerConnect {
+            .send(InternalServiceRequest::PeerConnect {
                 uuid: uuid_a,
                 cid: cid_a,
                 username: String::from("peer.a"),
@@ -517,11 +539,12 @@ mod tests {
                 peer_username: String::from("peer.b"),
                 udp_mode: Default::default(),
                 session_security_settings: Default::default(),
+                request_id: Uuid::new_v4(),
             })
             .unwrap();
 
         to_service_b
-            .send(InternalServicePayload::PeerConnect {
+            .send(InternalServiceRequest::PeerConnect {
                 uuid: uuid_b,
                 cid: cid_b,
                 username: String::from("peer.b"),
@@ -529,12 +552,16 @@ mod tests {
                 peer_username: String::from("peer.a"),
                 udp_mode: Default::default(),
                 session_security_settings: Default::default(),
+                request_id: Uuid::new_v4(),
             })
             .unwrap();
 
         let item = from_service_b.recv().await.unwrap();
         match item {
-            InternalServiceResponse::PeerConnectSuccess(PeerConnectSuccess { cid }) => {
+            InternalServiceResponse::PeerConnectSuccess(PeerConnectSuccess {
+                cid,
+                request_id: _,
+            }) => {
                 assert_eq!(cid, cid_b);
             }
             _ => {
@@ -545,7 +572,10 @@ mod tests {
 
         let item = from_service_a.recv().await.unwrap();
         match item {
-            InternalServiceResponse::PeerConnectSuccess(PeerConnectSuccess { cid }) => {
+            InternalServiceResponse::PeerConnectSuccess(PeerConnectSuccess {
+                cid,
+                request_id: _,
+            }) => {
                 assert_eq!(cid, cid_a);
                 Ok((
                     to_service_a,
@@ -600,12 +630,13 @@ mod tests {
         .await?;
 
         let service_a_message = Vec::from("Hello World");
-        let service_a_message_payload = InternalServicePayload::Message {
+        let service_a_message_payload = InternalServiceRequest::Message {
             uuid: uuid_a,
             message: service_a_message.clone(),
             cid: cid_a,
             peer_cid: Some(cid_b),
             security_level: Default::default(),
+            request_id: Uuid::new_v4(),
         };
         to_service_a.send(service_a_message_payload).unwrap();
         let deserialized_service_a_message_response = from_service_a.recv().await.unwrap();
@@ -620,6 +651,7 @@ mod tests {
                 message,
                 cid: cid_a,
                 peer_cid: _cid_b,
+                request_id: _,
             }) = deserialized_service_a_message_response
             {
                 assert_eq!(&*service_a_message, &*message);
@@ -706,17 +738,18 @@ mod tests {
     }
 
     async fn test_kv_for_service(
-        to_service: &UnboundedSender<InternalServicePayload>,
+        to_service: &UnboundedSender<InternalServiceRequest>,
         from_service: &mut UnboundedReceiver<InternalServiceResponse>,
         uuid: Uuid,
         cid: u64,
         peer_cid: Option<u64>,
     ) -> Result<(), Box<dyn Error>> {
         // test get_all_kv
-        to_service.send(InternalServicePayload::LocalDBGetAllKV {
+        to_service.send(InternalServiceRequest::LocalDBGetAllKV {
             uuid,
             cid,
             peer_cid,
+            request_id: Uuid::new_v4(),
         })?;
 
         if let InternalServiceResponse::LocalDBGetAllKVSuccess(resp) =
@@ -731,12 +764,13 @@ mod tests {
 
         // test set_kv
         let value = Vec::from("Hello, World!");
-        to_service.send(InternalServicePayload::LocalDBSetKV {
+        to_service.send(InternalServiceRequest::LocalDBSetKV {
             uuid,
             cid,
             peer_cid,
             key: "tmp".to_string(),
             value: value.clone(),
+            request_id: Uuid::new_v4(),
         })?;
 
         if let InternalServiceResponse::LocalDBSetKVSuccess(resp) =
@@ -750,11 +784,12 @@ mod tests {
         }
 
         // test get_kv
-        to_service.send(InternalServicePayload::LocalDBGetKV {
+        to_service.send(InternalServiceRequest::LocalDBGetKV {
             uuid,
             cid,
             peer_cid,
             key: "tmp".to_string(),
+            request_id: Uuid::new_v4(),
         })?;
 
         if let InternalServiceResponse::LocalDBGetKVSuccess(resp) =
@@ -769,10 +804,11 @@ mod tests {
         }
 
         // test get_all_kv
-        to_service.send(InternalServicePayload::LocalDBGetAllKV {
+        to_service.send(InternalServiceRequest::LocalDBGetAllKV {
             uuid,
             cid,
             peer_cid,
+            request_id: Uuid::new_v4(),
         })?;
 
         if let InternalServiceResponse::LocalDBGetAllKVSuccess(resp) =
@@ -790,11 +826,12 @@ mod tests {
         }
 
         // test delete_kv
-        to_service.send(InternalServicePayload::LocalDBDeleteKV {
+        to_service.send(InternalServiceRequest::LocalDBDeleteKV {
             uuid,
             cid,
             peer_cid,
             key: "tmp".to_string(),
+            request_id: Uuid::new_v4(),
         })?;
 
         if let InternalServiceResponse::LocalDBDeleteKVSuccess(resp) =

--- a/citadel_workspace_types/src/lib.rs
+++ b/citadel_workspace_types/src/lib.rs
@@ -13,38 +13,45 @@ use uuid::Uuid;
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ConnectSuccess {
     pub cid: u64,
+    pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ConnectionFailure {
     pub message: String,
+    pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RegisterSuccess {
     pub id: Uuid,
+    pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RegisterFailure {
     pub message: String,
+    pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ServiceConnectionAccepted {
     pub id: Uuid,
+    pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MessageSent {
     pub cid: u64,
-    pub peer_cid: Option<u64>, // TODO: investigate passing a message hash or a trace id
+    pub peer_cid: Option<u64>,
+    pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MessageSendError {
     pub cid: u64,
     pub message: String,
+    pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -52,59 +59,68 @@ pub struct MessageReceived {
     pub message: BytesMut,
     pub cid: u64,
     pub peer_cid: u64,
+    pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Disconnected {
     pub cid: u64,
     pub peer_cid: Option<u64>,
+    pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DisconnectFailure {
     pub cid: u64,
     pub message: String,
+    pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SendFileSuccess {
     pub cid: u64,
+    pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SendFileFailure {
     pub cid: u64,
     pub message: String,
+    pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PeerConnectSuccess {
     pub cid: u64,
+    pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PeerConnectFailure {
     pub cid: u64,
     pub message: String,
+    pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PeerDisconnectSuccess {
     pub cid: u64,
-    pub ticket: u128,
+    pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PeerDisconnectFailure {
     pub cid: u64,
     pub message: String,
+    pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PeerRegisterSuccess {
     pub cid: u64,
     pub peer_cid: u64,
-    pub username: String,
+    pub peer_username: String,
+    pub request_id: Option<Uuid>,
     // TODO: add access to MutualPeer
 }
 
@@ -112,6 +128,7 @@ pub struct PeerRegisterSuccess {
 pub struct PeerRegisterFailure {
     pub cid: u64,
     pub message: String,
+    pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -120,6 +137,7 @@ pub struct LocalDBGetKVSuccess {
     pub peer_cid: Option<u64>,
     pub key: String,
     pub value: Vec<u8>,
+    pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -127,6 +145,7 @@ pub struct LocalDBGetKVFailure {
     pub cid: u64,
     pub peer_cid: Option<u64>,
     pub message: String,
+    pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -134,6 +153,7 @@ pub struct LocalDBSetKVSuccess {
     pub cid: u64,
     pub peer_cid: Option<u64>,
     pub key: String,
+    pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -141,6 +161,7 @@ pub struct LocalDBSetKVFailure {
     pub cid: u64,
     pub peer_cid: Option<u64>,
     pub message: String,
+    pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -148,6 +169,7 @@ pub struct LocalDBDeleteKVSuccess {
     pub cid: u64,
     pub peer_cid: Option<u64>,
     pub key: String,
+    pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -155,6 +177,7 @@ pub struct LocalDBDeleteKVFailure {
     pub cid: u64,
     pub peer_cid: Option<u64>,
     pub message: String,
+    pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -162,6 +185,7 @@ pub struct LocalDBGetAllKVSuccess {
     pub cid: u64,
     pub peer_cid: Option<u64>,
     pub map: HashMap<String, Vec<u8>>,
+    pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -169,12 +193,14 @@ pub struct LocalDBGetAllKVFailure {
     pub cid: u64,
     pub peer_cid: Option<u64>,
     pub message: String,
+    pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct LocalDBClearAllKVSuccess {
     pub cid: u64,
     pub peer_cid: Option<u64>,
+    pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -182,6 +208,13 @@ pub struct LocalDBClearAllKVFailure {
     pub cid: u64,
     pub peer_cid: Option<u64>,
     pub message: String,
+    pub request_id: Option<Uuid>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GetSessions {
+    pub sessions: Vec<SessionInformation>,
+    pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -214,12 +247,15 @@ pub enum InternalServiceResponse {
     LocalDBGetAllKVFailure(LocalDBGetAllKVFailure),
     LocalDBClearAllKVSuccess(LocalDBClearAllKVSuccess),
     LocalDBClearAllKVFailure(LocalDBClearAllKVFailure),
+    GetSessions(GetSessions),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum InternalServicePayload {
+pub enum InternalServiceRequest {
     Connect {
         uuid: Uuid,
+        // A user-provided unique ID that will be returned in the response
+        request_id: Uuid,
         username: String,
         password: SecBuffer,
         connect_mode: ConnectMode,
@@ -229,6 +265,7 @@ pub enum InternalServicePayload {
     },
     Register {
         uuid: Uuid,
+        request_id: Uuid,
         server_addr: SocketAddr,
         full_name: String,
         username: String,
@@ -238,6 +275,7 @@ pub enum InternalServicePayload {
     },
     Message {
         uuid: Uuid,
+        request_id: Uuid,
         message: Vec<u8>,
         cid: u64,
         // if None, send to server, otherwise, send to p2p
@@ -246,10 +284,12 @@ pub enum InternalServicePayload {
     },
     Disconnect {
         uuid: Uuid,
+        request_id: Uuid,
         cid: u64,
     },
     SendFile {
         uuid: Uuid,
+        request_id: Uuid,
         source: PathBuf,
         cid: u64,
         chunk_size: usize,
@@ -261,14 +301,17 @@ pub enum InternalServicePayload {
         delete_on_pull: bool,
         cid: u64,
         uuid: Uuid,
+        request_id: Uuid,
     },
     StartGroup {
         initial_users_to_invite: Option<Vec<UserIdentifier>>,
         cid: u64,
         uuid: Uuid,
+        request_id: Uuid,
     },
     PeerConnect {
         uuid: Uuid,
+        request_id: Uuid,
         cid: u64,
         username: String,
         peer_cid: u64,
@@ -278,23 +321,27 @@ pub enum InternalServicePayload {
     },
     PeerDisconnect {
         uuid: Uuid,
+        request_id: Uuid,
         cid: u64,
         peer_cid: u64,
     },
     PeerRegister {
         uuid: Uuid,
+        request_id: Uuid,
         cid: u64,
         peer_id: UserIdentifier,
         connect_after_register: bool,
     },
     LocalDBGetKV {
         uuid: Uuid,
+        request_id: Uuid,
         cid: u64,
         peer_cid: Option<u64>,
         key: String,
     },
     LocalDBSetKV {
         uuid: Uuid,
+        request_id: Uuid,
         cid: u64,
         peer_cid: Option<u64>,
         key: String,
@@ -302,18 +349,38 @@ pub enum InternalServicePayload {
     },
     LocalDBDeleteKV {
         uuid: Uuid,
+        request_id: Uuid,
         cid: u64,
         peer_cid: Option<u64>,
         key: String,
     },
     LocalDBGetAllKV {
         uuid: Uuid,
+        request_id: Uuid,
         cid: u64,
         peer_cid: Option<u64>,
     },
     LocalDBClearAllKV {
         uuid: Uuid,
+        request_id: Uuid,
         cid: u64,
         peer_cid: Option<u64>,
     },
+    GetSessions {
+        uuid: Uuid,
+        request_id: Uuid,
+    },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct SessionInformation {
+    pub cid: u64,
+    pub peer_connections: HashMap<u64, PeerSessionInformation>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct PeerSessionInformation {
+    pub cid: u64,
+    pub peer_cid: u64,
+    pub peer_username: String,
 }

--- a/service/src/empty_server.rs
+++ b/service/src/empty_server.rs
@@ -8,7 +8,7 @@ use structopt::StructOpt;
 async fn main() -> Result<(), Box<dyn Error>> {
     citadel_logging::setup_log();
     let opts: Options = Options::from_args();
-    let service = EmptyKernel::default();
+    let service = EmptyKernel;
     NodeBuilder::default()
         .with_backend(BackendType::InMemory)
         .with_node_type(NodeType::server(opts.bind)?)


### PR DESCRIPTION
TCP clients will now need to add random request IDs whenever creating a request. This can be done using `uuid::Uuid::new_v4()`. In typescript code, we will need to use:

```
import {v4 as uuidv4} from 'uuid';
let request_id = uuidv4();
```