### PR TITLE
Forward peer requests to TCP client

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - uses: Avarok-Cybersecurity/gh-actions-deps@master
       - uses: taiki-e/install-action@nextest
+      - run: cargo test test_internal_service_group_create -- --nocapture
+        if: startsWith(matrix.os, 'ubuntu')
       - run: cargo nextest run --package citadel-internal-service --features=vendored
         if: startsWith(matrix.os, 'windows')
       - run: cargo nextest run --package citadel-internal-service

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
-      - uses: Avarok-Cybersecurity/gh-actions-deps@tbraun96-patch-1
+      - uses: Avarok-Cybersecurity/gh-actions-deps@master
       - uses: taiki-e/install-action@nextest
       - run: cargo nextest run --package citadel-internal-service --features=vendored
         if: startsWith(matrix.os, 'windows')
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: Avarok-Cybersecurity/gh-actions-deps@tbraun96-patch-1
+      - uses: Avarok-Cybersecurity/gh-actions-deps@master
       - run: rustup component add clippy-preview
       - run: cargo clippy --tests -- -D warnings
 
@@ -41,5 +41,5 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: Avarok-Cybersecurity/gh-actions-deps@tbraun96-patch-1
+      - uses: Avarok-Cybersecurity/gh-actions-deps@master
       - run: cargo fmt --check

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
-      - uses: Avarok-Cybersecurity/gh-actions-deps@master
+      - uses: Avarok-Cybersecurity/gh-actions-deps@tbraun96-patch-1
       - uses: taiki-e/install-action@nextest
       - run: cargo nextest run --package citadel-internal-service --features=vendored
         if: startsWith(matrix.os, 'windows')
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: Avarok-Cybersecurity/gh-actions-deps@master
+      - uses: Avarok-Cybersecurity/gh-actions-deps@tbraun96-patch-1
       - run: rustup component add clippy-preview
       - run: cargo clippy --tests -- -D warnings
 
@@ -41,5 +41,5 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: Avarok-Cybersecurity/gh-actions-deps@master
+      - uses: Avarok-Cybersecurity/gh-actions-deps@tbraun96-patch-1
       - run: cargo fmt --check

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,8 +24,6 @@ jobs:
     steps:
       - uses: Avarok-Cybersecurity/gh-actions-deps@master
       - uses: taiki-e/install-action@nextest
-      - run: cargo test test_internal_service_group_create -- --nocapture
-        if: startsWith(matrix.os, 'ubuntu')
       - run: cargo nextest run --package citadel-internal-service --features=vendored
         if: startsWith(matrix.os, 'windows')
       - run: cargo nextest run --package citadel-internal-service

--- a/citadel-internal-service-macros/src/lib.rs
+++ b/citadel-internal-service-macros/src/lib.rs
@@ -4,6 +4,15 @@ use syn::{parse_macro_input, Data, DataEnum, DeriveInput, Ident};
 
 #[proc_macro_derive(IsError)]
 pub fn is_error_derive(input: TokenStream) -> TokenStream {
+    generate_function(input, "Failure", "is_error")
+}
+
+#[proc_macro_derive(IsNotification)]
+pub fn is_notification_derive(input: TokenStream) -> TokenStream {
+    generate_function(input, "Notification", "is_notification")
+}
+
+fn generate_function(input: TokenStream, contains: &str, function_name: &str) -> TokenStream {
     // Parse the input tokens into a syntax tree
     let input = parse_macro_input!(input as DeriveInput);
 
@@ -13,16 +22,19 @@ pub fn is_error_derive(input: TokenStream) -> TokenStream {
         data
     } else {
         // This macro only supports enums
-        panic!("IsError can only be derived for enums");
+        panic!("{function_name} can only be derived for enums");
     };
 
+    // Convert the function name to a tokenstream
+    let function_name = Ident::new(function_name, name.span());
+
     // Generate match arms for each enum variant
-    let match_arms = generate_match_arms(name, &data);
+    let match_arms = generate_match_arms(name, &data, contains);
 
     // Generate the implementation of the `is_error` method
     let expanded = quote! {
         impl #name {
-            pub fn is_error(&self) -> bool {
+            pub fn #function_name(&self) -> bool {
                 match self {
                     #(#match_arms)*
                 }
@@ -34,14 +46,18 @@ pub fn is_error_derive(input: TokenStream) -> TokenStream {
     TokenStream::from(expanded)
 }
 
-fn generate_match_arms(name: &Ident, data_enum: &DataEnum) -> Vec<proc_macro2::TokenStream> {
+fn generate_match_arms(
+    name: &Ident,
+    data_enum: &DataEnum,
+    contains: &str,
+) -> Vec<proc_macro2::TokenStream> {
     data_enum
         .variants
         .iter()
         .map(|variant| {
             let variant_ident = &variant.ident;
             let variant_str = variant_ident.to_string();
-            let is_error = variant_str.contains("Failure");
+            let is_error = variant_str.contains(contains);
 
             // Match against each variant, ignoring any inner data
             quote! {

--- a/citadel-internal-service-types/src/lib.rs
+++ b/citadel-internal-service-types/src/lib.rs
@@ -1,5 +1,5 @@
 use bytes::BytesMut;
-use citadel_internal_service_macros::IsError;
+use citadel_internal_service_macros::{IsError, IsNotification};
 pub use citadel_types::prelude::{
     ConnectMode, MemberState, MessageGroupKey, ObjectTransferStatus, SecBuffer, SecurityLevel,
     SessionSecuritySettings, TransferType, UdpMode, UserIdentifier, VirtualObjectMetadata,
@@ -139,7 +139,7 @@ pub struct PeerDisconnectFailure {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct PeerConnectRequest {
+pub struct PeerConnectNotification {
     pub cid: u64,
     pub peer_cid: u64,
     pub session_security_settings: SessionSecuritySettings,
@@ -148,7 +148,7 @@ pub struct PeerConnectRequest {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct PeerRegisterRequest {
+pub struct PeerRegisterNotification {
     pub cid: u64,
     pub peer_cid: u64,
     pub peer_username: String,
@@ -541,7 +541,7 @@ pub struct GetSessions {
 pub struct FileTransferRequest {
     pub cid: u64,
     pub peer_cid: u64,
-    pub metadata: VirtualObjectMetadata, // TODO: metadata: VirtualObjectMetadata
+    pub metadata: VirtualObjectMetadata,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -561,7 +561,7 @@ pub struct FileTransferTick {
     pub status: ObjectTransferStatus,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, IsError)]
+#[derive(Serialize, Deserialize, Debug, Clone, IsError, IsNotification)]
 pub enum InternalServiceResponse {
     ConnectSuccess(ConnectSuccess),
     ConnectionFailure(ConnectionFailure),
@@ -584,8 +584,8 @@ pub enum InternalServiceResponse {
     DeleteVirtualFileFailure(DeleteVirtualFileFailure),
     PeerConnectSuccess(PeerConnectSuccess),
     PeerConnectFailure(PeerConnectFailure),
-    PeerConnectRequest(PeerConnectRequest),
-    PeerRegisterRequest(PeerRegisterRequest),
+    PeerConnectNotification(PeerConnectNotification),
+    PeerRegisterNotification(PeerRegisterNotification),
     PeerDisconnectSuccess(PeerDisconnectSuccess),
     PeerDisconnectFailure(PeerDisconnectFailure),
     PeerRegisterSuccess(PeerRegisterSuccess),
@@ -871,5 +871,22 @@ mod tests {
         });
         assert!(!success_response.is_error());
         assert!(error_response.is_error());
+    }
+
+    #[test]
+    fn test_is_notification_derive() {
+        let success_response = InternalServiceResponse::ConnectSuccess(ConnectSuccess {
+            cid: 0,
+            request_id: None,
+        });
+        let notification_response =
+            InternalServiceResponse::PeerRegisterNotification(PeerRegisterNotification {
+                cid: 0,
+                peer_cid: 0,
+                peer_username: "".to_string(),
+                request_id: None,
+            });
+        assert!(!success_response.is_notification());
+        assert!(notification_response.is_notification());
     }
 }

--- a/citadel-internal-service-types/src/lib.rs
+++ b/citadel-internal-service-types/src/lib.rs
@@ -139,6 +139,23 @@ pub struct PeerDisconnectFailure {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PeerConnectRequest {
+    pub cid: u64,
+    pub peer_cid: u64,
+    pub session_security_settings: SessionSecuritySettings,
+    pub udp_mode: UdpMode,
+    pub request_id: Option<Uuid>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PeerRegisterRequest {
+    pub cid: u64,
+    pub peer_cid: u64,
+    pub peer_username: String,
+    pub request_id: Option<Uuid>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PeerRegisterSuccess {
     pub cid: u64,
     pub peer_cid: u64,
@@ -567,6 +584,8 @@ pub enum InternalServiceResponse {
     DeleteVirtualFileFailure(DeleteVirtualFileFailure),
     PeerConnectSuccess(PeerConnectSuccess),
     PeerConnectFailure(PeerConnectFailure),
+    PeerConnectRequest(PeerConnectRequest),
+    PeerRegisterRequest(PeerRegisterRequest),
     PeerDisconnectSuccess(PeerDisconnectSuccess),
     PeerDisconnectFailure(PeerDisconnectFailure),
     PeerRegisterSuccess(PeerRegisterSuccess),

--- a/citadel-internal-service-types/src/lib.rs
+++ b/citadel-internal-service-types/src/lib.rs
@@ -18,7 +18,7 @@ pub struct ConnectSuccess {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ConnectionFailure {
+pub struct ConnectFailure {
     pub message: String,
     pub request_id: Option<Uuid>,
 }
@@ -38,21 +38,21 @@ pub struct RegisterFailure {
 pub struct ServiceConnectionAccepted;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct MessageSent {
+pub struct MessageSendSuccess {
     pub cid: u64,
     pub peer_cid: Option<u64>,
     pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct MessageSendError {
+pub struct MessageSendFailure {
     pub cid: u64,
     pub message: String,
     pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct MessageReceived {
+pub struct MessageNotification {
     pub message: BytesMut,
     pub cid: u64,
     pub peer_cid: u64,
@@ -60,7 +60,7 @@ pub struct MessageReceived {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct Disconnected {
+pub struct DisconnectNotification {
     pub cid: u64,
     pub peer_cid: Option<u64>,
     pub request_id: Option<Uuid>,
@@ -74,13 +74,13 @@ pub struct DisconnectFailure {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct SendFileRequestSent {
+pub struct SendFileRequestSuccess {
     pub cid: u64,
     pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct SendFileFailure {
+pub struct SendFileRequestFailure {
     pub cid: u64,
     pub message: String,
     pub request_id: Option<Uuid>,
@@ -236,7 +236,7 @@ pub struct GroupEndFailure {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct GroupEnded {
+pub struct GroupEndNotification {
     pub cid: u64,
     pub group_key: MessageGroupKey,
     pub success: bool,
@@ -244,7 +244,7 @@ pub struct GroupEnded {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct GroupLeft {
+pub struct GroupLeaveNotification {
     pub cid: u64,
     pub group_key: MessageGroupKey,
     pub success: bool,
@@ -253,7 +253,7 @@ pub struct GroupLeft {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct GroupMessageReceived {
+pub struct GroupMessageNotification {
     pub cid: u64,
     pub peer_cid: u64,
     pub message: BytesMut,
@@ -284,7 +284,7 @@ pub struct GroupMessageFailure {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct GroupInvitation {
+pub struct GroupInviteNotification {
     pub cid: u64,
     pub peer_cid: u64,
     pub group_key: MessageGroupKey,
@@ -328,7 +328,7 @@ pub struct GroupMembershipResponse {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct GroupRequestJoinPending {
+pub struct GroupRequestJoinPendingNotification {
     pub cid: u64,
     pub group_key: MessageGroupKey,
     pub result: Result<(), String>,
@@ -336,7 +336,7 @@ pub struct GroupRequestJoinPending {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct GroupDisconnected {
+pub struct GroupDisconnectNotification {
     pub cid: u64,
     pub group_key: MessageGroupKey,
     pub request_id: Option<Uuid>,
@@ -357,7 +357,7 @@ pub struct GroupKickFailure {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct GroupListGroupsForSuccess {
+pub struct GroupListGroupsSuccess {
     pub cid: u64,
     pub peer_cid: u64,
     pub group_list: Option<Vec<MessageGroupKey>>,
@@ -365,7 +365,7 @@ pub struct GroupListGroupsForSuccess {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct GroupListGroupsForFailure {
+pub struct GroupListGroupsFailure {
     pub cid: u64,
     pub message: String,
     pub request_id: Option<Uuid>,
@@ -379,7 +379,7 @@ pub struct GroupListGroupsResponse {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct GroupJoinRequestReceived {
+pub struct GroupJoinRequestNotification {
     pub cid: u64,
     pub peer_cid: u64,
     pub group_key: MessageGroupKey,
@@ -387,14 +387,14 @@ pub struct GroupJoinRequestReceived {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct GroupRequestJoinAccepted {
+pub struct GroupRequestJoinAcceptResponse {
     pub cid: u64,
     pub group_key: MessageGroupKey,
     pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct GroupRequestDeclined {
+pub struct GroupRequestJoinDeclineResponse {
     pub cid: u64,
     pub group_key: MessageGroupKey,
     pub request_id: Option<Uuid>,
@@ -415,7 +415,7 @@ pub struct GroupRequestJoinFailure {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct GroupMemberStateChanged {
+pub struct GroupMemberStateChangeNotification {
     pub cid: u64,
     pub group_key: MessageGroupKey,
     pub state: MemberState,
@@ -495,7 +495,7 @@ pub struct LocalDBClearAllKVSuccess {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ListAllPeers {
+pub struct ListAllPeersResponse {
     pub cid: u64,
     pub online_status: HashMap<u64, bool>,
     pub request_id: Option<Uuid>,
@@ -516,7 +516,7 @@ pub struct ListRegisteredPeersFailure {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ListRegisteredPeers {
+pub struct ListRegisteredPeersResponse {
     pub cid: u64,
     pub peers: HashMap<u64, PeerSessionInformation>,
     pub online_status: HashMap<u64, bool>,
@@ -532,20 +532,20 @@ pub struct LocalDBClearAllKVFailure {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct GetSessions {
+pub struct GetSessionsResponse {
     pub sessions: Vec<SessionInformation>,
     pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct FileTransferRequest {
+pub struct FileTransferRequestNotification {
     pub cid: u64,
     pub peer_cid: u64,
     pub metadata: VirtualObjectMetadata,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct FileTransferStatus {
+pub struct FileTransferStatusNotification {
     pub cid: u64,
     pub object_id: u64,
     pub success: bool,
@@ -555,7 +555,7 @@ pub struct FileTransferStatus {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct FileTransferTick {
+pub struct FileTransferTickNotification {
     pub cid: u64,
     pub peer_cid: u64,
     pub status: ObjectTransferStatus,
@@ -564,20 +564,20 @@ pub struct FileTransferTick {
 #[derive(Serialize, Deserialize, Debug, Clone, IsError, IsNotification)]
 pub enum InternalServiceResponse {
     ConnectSuccess(ConnectSuccess),
-    ConnectionFailure(ConnectionFailure),
+    ConnectFailure(ConnectFailure),
     RegisterSuccess(RegisterSuccess),
     RegisterFailure(RegisterFailure),
     ServiceConnectionAccepted(ServiceConnectionAccepted),
-    MessageSent(MessageSent),
-    MessageSendError(MessageSendError),
-    MessageReceived(MessageReceived),
-    Disconnected(Disconnected),
+    MessageSendSuccess(MessageSendSuccess),
+    MessageSendFailure(MessageSendFailure),
+    MessageNotification(MessageNotification),
+    DisconnectNotification(DisconnectNotification),
     DisconnectFailure(DisconnectFailure),
-    SendFileRequestSent(SendFileRequestSent),
-    SendFileFailure(SendFileFailure),
-    FileTransferRequest(FileTransferRequest),
-    FileTransferStatus(FileTransferStatus),
-    FileTransferTick(FileTransferTick),
+    SendFileRequestSuccess(SendFileRequestSuccess),
+    SendFileRequestFailure(SendFileRequestFailure),
+    FileTransferRequestNotification(FileTransferRequestNotification),
+    FileTransferStatusNotification(FileTransferStatusNotification),
+    FileTransferTickNotification(FileTransferTickNotification),
     DownloadFileSuccess(DownloadFileSuccess),
     DownloadFileFailure(DownloadFileFailure),
     DeleteVirtualFileSuccess(DeleteVirtualFileSuccess),
@@ -597,33 +597,33 @@ pub enum InternalServiceResponse {
     GroupCreateFailure(GroupCreateFailure),
     GroupLeaveSuccess(GroupLeaveSuccess),
     GroupLeaveFailure(GroupLeaveFailure),
-    GroupLeft(GroupLeft),
+    GroupLeaveNotification(GroupLeaveNotification),
     GroupEndSuccess(GroupEndSuccess),
     GroupEndFailure(GroupEndFailure),
-    GroupEnded(GroupEnded),
-    GroupMessageReceived(GroupMessageReceived),
+    GroupEndNotification(GroupEndNotification),
+    GroupMessageNotification(GroupMessageNotification),
     GroupMessageResponse(GroupMessageResponse),
     GroupMessageSuccess(GroupMessageSuccess),
     GroupMessageFailure(GroupMessageFailure),
-    GroupInvitation(GroupInvitation),
+    GroupInviteNotification(GroupInviteNotification),
     GroupInviteSuccess(GroupInviteSuccess),
     GroupInviteFailure(GroupInviteFailure),
     GroupRespondRequestSuccess(GroupRespondRequestSuccess),
     GroupRespondRequestFailure(GroupRespondRequestFailure),
     GroupMembershipResponse(GroupMembershipResponse),
-    GroupRequestJoinPending(GroupRequestJoinPending),
-    GroupDisconnected(GroupDisconnected),
+    GroupRequestJoinPendingNotification(GroupRequestJoinPendingNotification),
+    GroupDisconnectNotification(GroupDisconnectNotification),
     GroupKickSuccess(GroupKickSuccess),
     GroupKickFailure(GroupKickFailure),
-    GroupListGroupsForSuccess(GroupListGroupsForSuccess),
-    GroupListGroupsForFailure(GroupListGroupsForFailure),
+    GroupListGroupsSuccess(GroupListGroupsSuccess),
+    GroupListGroupsFailure(GroupListGroupsFailure),
     GroupListGroupsResponse(GroupListGroupsResponse),
-    GroupJoinRequestReceived(GroupJoinRequestReceived),
-    GroupRequestJoinAccepted(GroupRequestJoinAccepted),
-    GroupRequestDeclined(GroupRequestDeclined),
+    GroupJoinRequestNotification(GroupJoinRequestNotification),
+    GroupRequestJoinAcceptResponse(GroupRequestJoinAcceptResponse),
+    GroupRequestJoinDeclineResponse(GroupRequestJoinDeclineResponse),
     GroupRequestJoinSuccess(GroupRequestJoinSuccess),
-    GroupMemberStateChanged(GroupMemberStateChanged),
     GroupRequestJoinFailure(GroupRequestJoinFailure),
+    GroupMemberStateChangeNotification(GroupMemberStateChangeNotification),
     LocalDBGetKVSuccess(LocalDBGetKVSuccess),
     LocalDBGetKVFailure(LocalDBGetKVFailure),
     LocalDBSetKVSuccess(LocalDBSetKVSuccess),
@@ -634,11 +634,11 @@ pub enum InternalServiceResponse {
     LocalDBGetAllKVFailure(LocalDBGetAllKVFailure),
     LocalDBClearAllKVSuccess(LocalDBClearAllKVSuccess),
     LocalDBClearAllKVFailure(LocalDBClearAllKVFailure),
-    GetSessions(GetSessions),
-    GetAccountInformation(Accounts),
-    ListAllPeers(ListAllPeers),
+    GetSessionsResponse(GetSessionsResponse),
+    GetAccountInformationResponse(Accounts),
+    ListAllPeersResponse(ListAllPeersResponse),
     ListAllPeersFailure(ListAllPeersFailure),
-    ListRegisteredPeers(ListRegisteredPeers),
+    ListRegisteredPeersResponse(ListRegisteredPeersResponse),
     ListRegisteredPeersFailure(ListRegisteredPeersFailure),
 }
 
@@ -865,7 +865,7 @@ mod tests {
             cid: 0,
             request_id: None,
         });
-        let error_response = InternalServiceResponse::ConnectionFailure(ConnectionFailure {
+        let error_response = InternalServiceResponse::ConnectFailure(ConnectFailure {
             message: "test".to_string(),
             request_id: None,
         });

--- a/citadel-internal-service/src/kernel/mod.rs
+++ b/citadel-internal-service/src/kernel/mod.rs
@@ -230,11 +230,13 @@ impl NetKernel for CitadelWorkspaceService {
                             let mut server_connection_map = self.server_connection_map.lock().await;
                             if let Some(conn) = server_connection_map.remove(&implicated_cid) {
                                 (
-                                    InternalServiceResponse::Disconnected(Disconnected {
-                                        cid: implicated_cid,
-                                        peer_cid: None,
-                                        request_id: None,
-                                    }),
+                                    InternalServiceResponse::DisconnectNotification(
+                                        DisconnectNotification {
+                                            cid: implicated_cid,
+                                            peer_cid: None,
+                                            request_id: None,
+                                        },
+                                    ),
                                     conn.associated_tcp_connection,
                                 )
                             } else {
@@ -249,11 +251,13 @@ impl NetKernel for CitadelWorkspaceService {
                                 self.clear_peer_connection(implicated_cid, peer_cid).await
                             {
                                 (
-                                    InternalServiceResponse::Disconnected(Disconnected {
-                                        cid: implicated_cid,
-                                        peer_cid: Some(peer_cid),
-                                        request_id: None,
-                                    }),
+                                    InternalServiceResponse::DisconnectNotification(
+                                        DisconnectNotification {
+                                            cid: implicated_cid,
+                                            peer_cid: Some(peer_cid),
+                                            request_id: None,
+                                        },
+                                    ),
                                     conn.associated_tcp_connection,
                                 )
                             } else {
@@ -320,12 +324,13 @@ impl NetKernel for CitadelWorkspaceService {
                             );
                         } else {
                             // Send an update to the TCP client that way they can choose to accept or reject the transfer
-                            let response =
-                                InternalServiceResponse::FileTransferRequest(FileTransferRequest {
+                            let response = InternalServiceResponse::FileTransferRequestNotification(
+                                FileTransferRequestNotification {
                                     cid: implicated_cid,
                                     peer_cid,
                                     metadata,
-                                });
+                                },
+                            );
                             send_response_to_tcp_client(&self.tcp_connection_map, response, uuid)
                                 .await;
                             connection.add_object_transfer_handler(
@@ -392,11 +397,13 @@ impl NetKernel for CitadelWorkspaceService {
                     disconnect_response: _,
                 } => {
                     if let Some(conn) = self.clear_peer_connection(implicated_cid, peer_cid).await {
-                        let response = InternalServiceResponse::Disconnected(Disconnected {
-                            cid: implicated_cid,
-                            peer_cid: Some(peer_cid),
-                            request_id: None,
-                        });
+                        let response = InternalServiceResponse::DisconnectNotification(
+                            DisconnectNotification {
+                                cid: implicated_cid,
+                                peer_cid: Some(peer_cid),
+                                request_id: None,
+                            },
+                        );
                         send_response_to_tcp_client(
                             &self.tcp_connection_map,
                             response,
@@ -615,12 +622,14 @@ async fn handle_group_broadcast(
             GroupBroadcast::Invitation {
                 sender: peer_cid,
                 key: group_key,
-            } => Some(InternalServiceResponse::GroupInvitation(GroupInvitation {
-                cid: implicated_cid,
-                peer_cid,
-                group_key,
-                request_id: None,
-            })),
+            } => Some(InternalServiceResponse::GroupInviteNotification(
+                GroupInviteNotification {
+                    cid: implicated_cid,
+                    peer_cid,
+                    group_key,
+                    request_id: None,
+                },
+            )),
 
             GroupBroadcast::RequestJoin {
                 sender: peer_cid,
@@ -629,23 +638,27 @@ async fn handle_group_broadcast(
                 .groups
                 .get_mut(&group_key)
                 .map(|_group_connection| {
-                    InternalServiceResponse::GroupJoinRequestReceived(GroupJoinRequestReceived {
-                        cid: implicated_cid,
-                        peer_cid,
-                        group_key,
-                        request_id: None,
-                    })
+                    InternalServiceResponse::GroupJoinRequestNotification(
+                        GroupJoinRequestNotification {
+                            cid: implicated_cid,
+                            peer_cid,
+                            group_key,
+                            request_id: None,
+                        },
+                    )
                 }),
 
             GroupBroadcast::AcceptMembership { target: _, key: _ } => None,
 
-            GroupBroadcast::DeclineMembership { target: _, key } => Some(
-                InternalServiceResponse::GroupRequestDeclined(GroupRequestDeclined {
-                    cid: implicated_cid,
-                    group_key: key,
-                    request_id: None,
-                }),
-            ),
+            GroupBroadcast::DeclineMembership { target: _, key } => {
+                Some(InternalServiceResponse::GroupRequestJoinDeclineResponse(
+                    GroupRequestJoinDeclineResponse {
+                        cid: implicated_cid,
+                        group_key: key,
+                        request_id: None,
+                    },
+                ))
+            }
 
             GroupBroadcast::Message {
                 sender: peer_cid,
@@ -655,7 +668,7 @@ async fn handle_group_broadcast(
                 .groups
                 .get_mut(&group_key)
                 .map(|_group_connection| {
-                    InternalServiceResponse::GroupMessageReceived(GroupMessageReceived {
+                    InternalServiceResponse::GroupMessageNotification(GroupMessageNotification {
                         cid: implicated_cid,
                         peer_cid,
                         message: message.into_buffer(),
@@ -682,8 +695,8 @@ async fn handle_group_broadcast(
             GroupBroadcast::MemberStateChanged {
                 key: group_key,
                 state,
-            } => Some(InternalServiceResponse::GroupMemberStateChanged(
-                GroupMemberStateChanged {
+            } => Some(InternalServiceResponse::GroupMemberStateChangeNotification(
+                GroupMemberStateChangeNotification {
                     cid: implicated_cid,
                     group_key,
                     state,
@@ -695,33 +708,39 @@ async fn handle_group_broadcast(
                 key: group_key,
                 success,
                 message,
-            } => Some(InternalServiceResponse::GroupLeft(GroupLeft {
-                cid: implicated_cid,
-                group_key,
-                success,
-                message,
-                request_id: None,
-            })),
+            } => Some(InternalServiceResponse::GroupLeaveNotification(
+                GroupLeaveNotification {
+                    cid: implicated_cid,
+                    group_key,
+                    success,
+                    message,
+                    request_id: None,
+                },
+            )),
 
             GroupBroadcast::EndResponse {
                 key: group_key,
                 success,
-            } => Some(InternalServiceResponse::GroupEnded(GroupEnded {
-                cid: implicated_cid,
-                group_key,
-                success,
-                request_id: None,
-            })),
+            } => Some(InternalServiceResponse::GroupEndNotification(
+                GroupEndNotification {
+                    cid: implicated_cid,
+                    group_key,
+                    success,
+                    request_id: None,
+                },
+            )),
 
             GroupBroadcast::Disconnected { key: group_key } => connection
                 .groups
                 .get_mut(&group_key)
                 .map(|_group_connection| {
-                    InternalServiceResponse::GroupDisconnected(GroupDisconnected {
-                        cid: implicated_cid,
-                        group_key,
-                        request_id: None,
-                    })
+                    InternalServiceResponse::GroupDisconnectNotification(
+                        GroupDisconnectNotification {
+                            cid: implicated_cid,
+                            group_key,
+                            request_id: None,
+                        },
+                    )
                 }),
 
             GroupBroadcast::AddResponse {
@@ -754,12 +773,14 @@ async fn handle_group_broadcast(
             GroupBroadcast::GroupNonExists { key: _group_key } => None,
 
             GroupBroadcast::RequestJoinPending { result, key } => Some(
-                InternalServiceResponse::GroupRequestJoinPending(GroupRequestJoinPending {
-                    cid: implicated_cid,
-                    group_key: key,
-                    result,
-                    request_id: None,
-                }),
+                InternalServiceResponse::GroupRequestJoinPendingNotification(
+                    GroupRequestJoinPendingNotification {
+                        cid: implicated_cid,
+                        group_key: key,
+                        result,
+                        request_id: None,
+                    },
+                ),
             ),
 
             _ => None,
@@ -797,11 +818,13 @@ fn spawn_tick_updater(
                 let status_message = status.clone();
                 match tcp_connection_map.lock().await.get(&uuid) {
                     Some(entry) => {
-                        let message = InternalServiceResponse::FileTransferTick(FileTransferTick {
-                            cid: implicated_cid,
-                            peer_cid,
-                            status: status_message,
-                        });
+                        let message = InternalServiceResponse::FileTransferTickNotification(
+                            FileTransferTickNotification {
+                                cid: implicated_cid,
+                                peer_cid,
+                                status: status_message,
+                            },
+                        );
                         match entry.send(message.clone()) {
                             Ok(_res) => {
                                 info!(target: "citadel", "File Transfer Status Tick Sent");

--- a/citadel-internal-service/src/kernel/mod.rs
+++ b/citadel-internal-service/src/kernel/mod.rs
@@ -431,13 +431,14 @@ impl NetKernel for CitadelWorkspaceService {
                     info!(target: "citadel", "User {implicated_cid:?} received Register Request from {peer_cid:?}");
                     let mut server_connection_map = self.server_connection_map.lock().await;
                     if let Some(connection) = server_connection_map.get_mut(&implicated_cid) {
-                        let response =
-                            InternalServiceResponse::PeerRegisterRequest(PeerRegisterRequest {
+                        let response = InternalServiceResponse::PeerRegisterNotification(
+                            PeerRegisterNotification {
                                 cid: implicated_cid,
                                 peer_cid,
                                 peer_username: inviter_username,
                                 request_id: None,
-                            });
+                            },
+                        );
                         send_response_to_tcp_client(
                             &self.tcp_connection_map,
                             response,
@@ -460,14 +461,15 @@ impl NetKernel for CitadelWorkspaceService {
                     info!(target: "citadel", "User {implicated_cid:?} received Connect Request from {peer_cid:?}");
                     let mut server_connection_map = self.server_connection_map.lock().await;
                     if let Some(connection) = server_connection_map.get_mut(&implicated_cid) {
-                        let response =
-                            InternalServiceResponse::PeerConnectRequest(PeerConnectRequest {
+                        let response = InternalServiceResponse::PeerConnectNotification(
+                            PeerConnectNotification {
                                 cid: implicated_cid,
                                 peer_cid,
                                 session_security_settings,
                                 udp_mode,
                                 request_id: None,
-                            });
+                            },
+                        );
                         send_response_to_tcp_client(
                             &self.tcp_connection_map,
                             response,

--- a/citadel-internal-service/src/kernel/mod.rs
+++ b/citadel-internal-service/src/kernel/mod.rs
@@ -420,15 +420,18 @@ impl NetKernel for CitadelWorkspaceService {
                 PeerSignal::PostRegister {
                     peer_conn_type:
                         PeerConnectionType::LocalGroupPeer {
-                            implicated_cid,
-                            peer_cid,
+                            implicated_cid: peer_cid,
+                            peer_cid: implicated_cid,
                         },
                     inviter_username,
                     invitee_username: _,
                     ticket_opt: _,
                     invitee_response: _,
                 } => {
-                    if let Some(conn) = self.clear_peer_connection(implicated_cid, peer_cid).await {
+                    info!(target: "citadel", "Received Register Request from {peer_cid:?}");
+                    let mut server_connection_map = self.server_connection_map.lock().await;
+                    if let Some(connection) = server_connection_map.get_mut(&implicated_cid) {
+                        info!(target: "citadel", "POST REGISTER CHECKPOINT");
                         let response =
                             InternalServiceResponse::PeerRegisterRequest(PeerRegisterRequest {
                                 cid: implicated_cid,
@@ -439,7 +442,7 @@ impl NetKernel for CitadelWorkspaceService {
                         send_response_to_tcp_client(
                             &self.tcp_connection_map,
                             response,
-                            conn.associated_tcp_connection,
+                            connection.associated_tcp_connection,
                         )
                         .await;
                     }
@@ -447,15 +450,18 @@ impl NetKernel for CitadelWorkspaceService {
                 PeerSignal::PostConnect {
                     peer_conn_type:
                         PeerConnectionType::LocalGroupPeer {
-                            implicated_cid,
-                            peer_cid,
+                            implicated_cid: peer_cid,
+                            peer_cid: implicated_cid,
                         },
                     ticket_opt: _,
                     invitee_response: _,
                     session_security_settings,
                     udp_mode,
                 } => {
-                    if let Some(conn) = self.clear_peer_connection(implicated_cid, peer_cid).await {
+                    info!(target: "citadel", "Received Connect Request from {peer_cid:?}");
+                    let mut server_connection_map = self.server_connection_map.lock().await;
+                    if let Some(connection) = server_connection_map.get_mut(&implicated_cid) {
+                        info!(target: "citadel", "POST CONNECT CHECKPOINT");
                         let response =
                             InternalServiceResponse::PeerConnectRequest(PeerConnectRequest {
                                 cid: implicated_cid,
@@ -467,7 +473,7 @@ impl NetKernel for CitadelWorkspaceService {
                         send_response_to_tcp_client(
                             &self.tcp_connection_map,
                             response,
-                            conn.associated_tcp_connection,
+                            connection.associated_tcp_connection,
                         )
                         .await;
                     }

--- a/citadel-internal-service/src/kernel/mod.rs
+++ b/citadel-internal-service/src/kernel/mod.rs
@@ -428,10 +428,9 @@ impl NetKernel for CitadelWorkspaceService {
                     ticket_opt: _,
                     invitee_response: _,
                 } => {
-                    info!(target: "citadel", "Received Register Request from {peer_cid:?}");
+                    info!(target: "citadel", "User {implicated_cid:?} received Register Request from {peer_cid:?}");
                     let mut server_connection_map = self.server_connection_map.lock().await;
                     if let Some(connection) = server_connection_map.get_mut(&implicated_cid) {
-                        info!(target: "citadel", "POST REGISTER CHECKPOINT");
                         let response =
                             InternalServiceResponse::PeerRegisterRequest(PeerRegisterRequest {
                                 cid: implicated_cid,
@@ -458,10 +457,9 @@ impl NetKernel for CitadelWorkspaceService {
                     session_security_settings,
                     udp_mode,
                 } => {
-                    info!(target: "citadel", "Received Connect Request from {peer_cid:?}");
+                    info!(target: "citadel", "User {implicated_cid:?} received Connect Request from {peer_cid:?}");
                     let mut server_connection_map = self.server_connection_map.lock().await;
                     if let Some(connection) = server_connection_map.get_mut(&implicated_cid) {
-                        info!(target: "citadel", "POST CONNECT CHECKPOINT");
                         let response =
                             InternalServiceResponse::PeerConnectRequest(PeerConnectRequest {
                                 cid: implicated_cid,

--- a/citadel-internal-service/src/kernel/mod.rs
+++ b/citadel-internal-service/src/kernel/mod.rs
@@ -417,6 +417,61 @@ impl NetKernel for CitadelWorkspaceService {
                     )
                     .await;
                 }
+                PeerSignal::PostRegister {
+                    peer_conn_type:
+                        PeerConnectionType::LocalGroupPeer {
+                            implicated_cid,
+                            peer_cid,
+                        },
+                    inviter_username,
+                    invitee_username: _,
+                    ticket_opt: _,
+                    invitee_response: _,
+                } => {
+                    if let Some(conn) = self.clear_peer_connection(implicated_cid, peer_cid).await {
+                        let response =
+                            InternalServiceResponse::PeerRegisterRequest(PeerRegisterRequest {
+                                cid: implicated_cid,
+                                peer_cid,
+                                peer_username: inviter_username,
+                                request_id: None,
+                            });
+                        send_response_to_tcp_client(
+                            &self.tcp_connection_map,
+                            response,
+                            conn.associated_tcp_connection,
+                        )
+                        .await;
+                    }
+                }
+                PeerSignal::PostConnect {
+                    peer_conn_type:
+                        PeerConnectionType::LocalGroupPeer {
+                            implicated_cid,
+                            peer_cid,
+                        },
+                    ticket_opt: _,
+                    invitee_response: _,
+                    session_security_settings,
+                    udp_mode,
+                } => {
+                    if let Some(conn) = self.clear_peer_connection(implicated_cid, peer_cid).await {
+                        let response =
+                            InternalServiceResponse::PeerConnectRequest(PeerConnectRequest {
+                                cid: implicated_cid,
+                                peer_cid,
+                                session_security_settings,
+                                udp_mode,
+                                request_id: None,
+                            });
+                        send_response_to_tcp_client(
+                            &self.tcp_connection_map,
+                            response,
+                            conn.associated_tcp_connection,
+                        )
+                        .await;
+                    }
+                }
                 _ => {}
             },
 

--- a/citadel-internal-service/src/kernel/request_handler.rs
+++ b/citadel-internal-service/src/kernel/request_handler.rs
@@ -47,7 +47,7 @@ pub async fn handle_request(
                         );
                     }
 
-                    let peers = ListRegisteredPeers {
+                    let peers = ListRegisteredPeersResponse {
                         cid,
                         peers: accounts,
                         online_status: peers
@@ -57,7 +57,7 @@ pub async fn handle_request(
                         request_id: Some(request_id),
                     };
 
-                    let response = InternalServiceResponse::ListRegisteredPeers(peers);
+                    let response = InternalServiceResponse::ListRegisteredPeersResponse(peers);
                     send_response_to_tcp_client(tcp_connection_map, response, uuid).await;
                 }
 
@@ -76,7 +76,7 @@ pub async fn handle_request(
         InternalServiceRequest::ListAllPeers { request_id, cid } => {
             match remote.get_local_group_peers(cid, None).await {
                 Ok(peers) => {
-                    let peers = ListAllPeers {
+                    let peers = ListAllPeersResponse {
                         cid,
                         online_status: peers
                             .into_iter()
@@ -86,7 +86,7 @@ pub async fn handle_request(
                         request_id: Some(request_id),
                     };
 
-                    let response = InternalServiceResponse::ListAllPeers(peers);
+                    let response = InternalServiceResponse::ListAllPeersResponse(peers);
                     send_response_to_tcp_client(tcp_connection_map, response, uuid).await;
                 }
 
@@ -172,7 +172,7 @@ pub async fn handle_request(
                 }
             }
 
-            let response = InternalServiceResponse::GetAccountInformation(Accounts {
+            let response = InternalServiceResponse::GetAccountInformationResponse(Accounts {
                 accounts: accounts_ret,
                 request_id: Some(request_id),
             });
@@ -207,7 +207,7 @@ pub async fn handle_request(
                 }
             }
 
-            let response = InternalServiceResponse::GetSessions(GetSessions {
+            let response = InternalServiceResponse::GetSessionsResponse(GetSessionsResponse {
                 sessions,
                 request_id: Some(request_id),
             });
@@ -261,7 +261,7 @@ pub async fn handle_request(
                     let connection_read_stream = async move {
                         while let Some(message) = stream.next().await {
                             let message =
-                                InternalServiceResponse::MessageReceived(MessageReceived {
+                                InternalServiceResponse::MessageNotification(MessageNotification {
                                     message: message.into_buffer(),
                                     cid,
                                     peer_cid: 0,
@@ -282,7 +282,7 @@ pub async fn handle_request(
                 }
 
                 Err(err) => {
-                    let response = InternalServiceResponse::ConnectionFailure(ConnectionFailure {
+                    let response = InternalServiceResponse::ConnectFailure(ConnectFailure {
                         message: err.into_string(),
                         request_id: Some(request_id),
                     });
@@ -371,7 +371,7 @@ pub async fn handle_request(
                             info!(target: "citadel","connection not found");
                             send_response_to_tcp_client(
                                 tcp_connection_map,
-                                InternalServiceResponse::MessageSendError(MessageSendError {
+                                InternalServiceResponse::MessageSendFailure(MessageSendFailure {
                                     cid,
                                     message: format!("Connection for {cid} not found"),
                                     request_id: Some(request_id),
@@ -389,11 +389,12 @@ pub async fn handle_request(
                             .unwrap();
                     }
 
-                    let response = InternalServiceResponse::MessageSent(MessageSent {
-                        cid,
-                        peer_cid,
-                        request_id: Some(request_id),
-                    });
+                    let response =
+                        InternalServiceResponse::MessageSendSuccess(MessageSendSuccess {
+                            cid,
+                            peer_cid,
+                            request_id: Some(request_id),
+                        });
                     send_response_to_tcp_client(tcp_connection_map, response, uuid).await;
                     info!(target: "citadel", "Into the message handler command send")
                 }
@@ -401,7 +402,7 @@ pub async fn handle_request(
                     info!(target: "citadel","connection not found");
                     send_response_to_tcp_client(
                         tcp_connection_map,
-                        InternalServiceResponse::MessageSendError(MessageSendError {
+                        InternalServiceResponse::MessageSendFailure(MessageSendFailure {
                             cid,
                             message: format!("Connection for {cid} not found"),
                             request_id: Some(request_id),
@@ -420,11 +421,12 @@ pub async fn handle_request(
             server_connection_map.lock().await.remove(&cid);
             match remote.send(request).await {
                 Ok(res) => {
-                    let disconnect_success = InternalServiceResponse::Disconnected(Disconnected {
-                        cid,
-                        peer_cid: None,
-                        request_id: Some(request_id),
-                    });
+                    let disconnect_success =
+                        InternalServiceResponse::DisconnectNotification(DisconnectNotification {
+                            cid,
+                            peer_cid: None,
+                            request_id: Some(request_id),
+                        });
                     send_response_to_tcp_client(tcp_connection_map, disconnect_success, uuid).await;
                     info!(target: "citadel", "Disconnected {res:?}")
                 }
@@ -486,10 +488,12 @@ pub async fn handle_request(
                             info!(target: "citadel","InternalServiceRequest Send File Success");
                             send_response_to_tcp_client(
                                 tcp_connection_map,
-                                InternalServiceResponse::SendFileRequestSent(SendFileRequestSent {
-                                    cid,
-                                    request_id: Some(request_id),
-                                }),
+                                InternalServiceResponse::SendFileRequestSuccess(
+                                    SendFileRequestSuccess {
+                                        cid,
+                                        request_id: Some(request_id),
+                                    },
+                                ),
                                 uuid,
                             )
                             .await;
@@ -499,11 +503,13 @@ pub async fn handle_request(
                             info!(target: "citadel","InternalServiceRequest Send File Failure");
                             send_response_to_tcp_client(
                                 tcp_connection_map,
-                                InternalServiceResponse::SendFileFailure(SendFileFailure {
-                                    cid,
-                                    message: err.into_string(),
-                                    request_id: Some(request_id),
-                                }),
+                                InternalServiceResponse::SendFileRequestFailure(
+                                    SendFileRequestFailure {
+                                        cid,
+                                        message: err.into_string(),
+                                        request_id: Some(request_id),
+                                    },
+                                ),
                                 uuid,
                             )
                             .await;
@@ -514,7 +520,7 @@ pub async fn handle_request(
                     info!(target: "citadel","server connection not found");
                     send_response_to_tcp_client(
                         tcp_connection_map,
-                        InternalServiceResponse::SendFileFailure(SendFileFailure {
+                        InternalServiceResponse::SendFileRequestFailure(SendFileRequestFailure {
                             cid,
                             message: "Server Connection Not Found".into(),
                             request_id: Some(request_id),
@@ -557,8 +563,8 @@ pub async fn handle_request(
                             Ok(_) => {
                                 send_response_to_tcp_client(
                                     tcp_connection_map,
-                                    InternalServiceResponse::FileTransferStatus(
-                                        FileTransferStatus {
+                                    InternalServiceResponse::FileTransferStatusNotification(
+                                        FileTransferStatusNotification {
                                             cid,
                                             object_id,
                                             success: true,
@@ -575,8 +581,8 @@ pub async fn handle_request(
                             Err(err) => {
                                 send_response_to_tcp_client(
                                     tcp_connection_map,
-                                    InternalServiceResponse::FileTransferStatus(
-                                        FileTransferStatus {
+                                    InternalServiceResponse::FileTransferStatusNotification(
+                                        FileTransferStatusNotification {
                                             cid,
                                             object_id,
                                             success: false,
@@ -900,13 +906,14 @@ pub async fn handle_request(
                             .await;
                             let connection_read_stream = async move {
                                 while let Some(message) = stream.next().await {
-                                    let message =
-                                        InternalServiceResponse::MessageReceived(MessageReceived {
+                                    let message = InternalServiceResponse::MessageNotification(
+                                        MessageNotification {
                                             message: message.into_buffer(),
                                             cid: connection_cid,
                                             peer_cid,
                                             request_id: Some(request_id),
-                                        });
+                                        },
+                                    );
                                     match hm_for_conn.lock().await.get(&uuid) {
                                         Some(entry) => match entry.send(message) {
                                             Ok(res) => res,
@@ -1745,8 +1752,8 @@ pub async fn handle_request(
                             {
                                 send_response_to_tcp_client(
                                     tcp_connection_map,
-                                    InternalServiceResponse::GroupListGroupsForSuccess(
-                                        GroupListGroupsForSuccess {
+                                    InternalServiceResponse::GroupListGroupsSuccess(
+                                        GroupListGroupsSuccess {
                                             cid,
                                             peer_cid,
                                             group_list: Some(groups),
@@ -1759,8 +1766,8 @@ pub async fn handle_request(
                             } else {
                                 send_response_to_tcp_client(
                                     tcp_connection_map,
-                                    InternalServiceResponse::GroupListGroupsForFailure(
-                                        GroupListGroupsForFailure {
+                                    InternalServiceResponse::GroupListGroupsFailure(
+                                        GroupListGroupsFailure {
                                             cid,
                                             message: "Could Not List Groups - Failed".to_string(),
                                             request_id: Some(request_id),
@@ -1773,8 +1780,8 @@ pub async fn handle_request(
                         } else {
                             send_response_to_tcp_client(
                                 tcp_connection_map,
-                                InternalServiceResponse::GroupListGroupsForFailure(
-                                    GroupListGroupsForFailure {
+                                InternalServiceResponse::GroupListGroupsFailure(
+                                    GroupListGroupsFailure {
                                         cid,
                                         message: "Could Not List Groups - Subscription Error"
                                             .to_string(),
@@ -1788,8 +1795,8 @@ pub async fn handle_request(
                     } else {
                         send_response_to_tcp_client(
                             tcp_connection_map,
-                            InternalServiceResponse::GroupListGroupsForFailure(
-                                GroupListGroupsForFailure {
+                            InternalServiceResponse::GroupListGroupsFailure(
+                                GroupListGroupsFailure {
                                     cid,
                                     message: "Could Not List Groups - Subscription Error"
                                         .to_string(),
@@ -1803,13 +1810,11 @@ pub async fn handle_request(
                 } else {
                     send_response_to_tcp_client(
                         tcp_connection_map,
-                        InternalServiceResponse::GroupListGroupsForFailure(
-                            GroupListGroupsForFailure {
-                                cid,
-                                message: "Could Not List Groups - Peer not found".to_string(),
-                                request_id: Some(request_id),
-                            },
-                        ),
+                        InternalServiceResponse::GroupListGroupsFailure(GroupListGroupsFailure {
+                            cid,
+                            message: "Could Not List Groups - Peer not found".to_string(),
+                            request_id: Some(request_id),
+                        }),
                         uuid,
                     )
                     .await;
@@ -1817,7 +1822,7 @@ pub async fn handle_request(
             } else {
                 send_response_to_tcp_client(
                     tcp_connection_map,
-                    InternalServiceResponse::GroupListGroupsForFailure(GroupListGroupsForFailure {
+                    InternalServiceResponse::GroupListGroupsFailure(GroupListGroupsFailure {
                         cid,
                         message: "Could Not List Groups - Connection not found".to_string(),
                         request_id: Some(request_id),
@@ -2316,19 +2321,21 @@ pub(crate) fn spawn_group_channel_receiver(
                 Some(entry) => {
                     log::trace!(target:"citadel", "User {implicated_cid:?} Received Group Broadcast: {inbound_group_broadcast:?}");
                     let message = match inbound_group_broadcast {
-                        GroupBroadcastPayload::Message { payload, sender } => Some(
-                            InternalServiceResponse::GroupMessageReceived(GroupMessageReceived {
-                                cid: implicated_cid,
-                                peer_cid: sender,
-                                message: payload.into_buffer(),
-                                group_key,
-                                request_id: None,
-                            }),
-                        ),
+                        GroupBroadcastPayload::Message { payload, sender } => {
+                            Some(InternalServiceResponse::GroupMessageNotification(
+                                GroupMessageNotification {
+                                    cid: implicated_cid,
+                                    peer_cid: sender,
+                                    message: payload.into_buffer(),
+                                    group_key,
+                                    request_id: None,
+                                },
+                            ))
+                        }
                         GroupBroadcastPayload::Event { payload } => match payload {
                             GroupBroadcast::RequestJoin { sender, key: _ } => {
-                                Some(InternalServiceResponse::GroupJoinRequestReceived(
-                                    GroupJoinRequestReceived {
+                                Some(InternalServiceResponse::GroupJoinRequestNotification(
+                                    GroupJoinRequestNotification {
                                         cid: implicated_cid,
                                         peer_cid: sender,
                                         group_key,
@@ -2337,8 +2344,8 @@ pub(crate) fn spawn_group_channel_receiver(
                                 ))
                             }
                             GroupBroadcast::MemberStateChanged { key: _, state } => {
-                                Some(InternalServiceResponse::GroupMemberStateChanged(
-                                    GroupMemberStateChanged {
+                                Some(InternalServiceResponse::GroupMemberStateChangeNotification(
+                                    GroupMemberStateChangeNotification {
                                         cid: implicated_cid,
                                         group_key,
                                         state,
@@ -2347,20 +2354,24 @@ pub(crate) fn spawn_group_channel_receiver(
                                 ))
                             }
                             GroupBroadcast::EndResponse { key, success } => {
-                                Some(InternalServiceResponse::GroupEnded(GroupEnded {
-                                    cid: implicated_cid,
-                                    group_key: key,
-                                    success,
-                                    request_id: None,
-                                }))
+                                Some(InternalServiceResponse::GroupEndNotification(
+                                    GroupEndNotification {
+                                        cid: implicated_cid,
+                                        group_key: key,
+                                        success,
+                                        request_id: None,
+                                    },
+                                ))
                             }
-                            GroupBroadcast::Disconnected { key } => Some(
-                                InternalServiceResponse::GroupDisconnected(GroupDisconnected {
-                                    cid: implicated_cid,
-                                    group_key: key,
-                                    request_id: None,
-                                }),
-                            ),
+                            GroupBroadcast::Disconnected { key } => {
+                                Some(InternalServiceResponse::GroupDisconnectNotification(
+                                    GroupDisconnectNotification {
+                                        cid: implicated_cid,
+                                        group_key: key,
+                                        request_id: None,
+                                    },
+                                ))
+                            }
                             GroupBroadcast::MessageResponse { key, success } => {
                                 Some(InternalServiceResponse::GroupMessageResponse(
                                     GroupMessageResponse {

--- a/citadel-internal-service/src/kernel/request_handler.rs
+++ b/citadel-internal-service/src/kernel/request_handler.rs
@@ -784,7 +784,7 @@ pub async fn handle_request(
                                     true => {
                                         let connect_command = InternalServiceRequest::PeerConnect {
                                             cid,
-                                            peer_cid: mutual_peer.cid.clone(),
+                                            peer_cid: mutual_peer.cid,
                                             udp_mode: Default::default(),
                                             session_security_settings,
                                             request_id,
@@ -805,7 +805,7 @@ pub async fn handle_request(
                                             InternalServiceResponse::PeerRegisterSuccess(
                                                 PeerRegisterSuccess {
                                                     cid,
-                                                    peer_cid: mutual_peer.cid.clone(),
+                                                    peer_cid: mutual_peer.cid,
                                                     peer_username: mutual_peer
                                                         .username
                                                         .clone()

--- a/citadel-internal-service/src/kernel/request_handler.rs
+++ b/citadel-internal-service/src/kernel/request_handler.rs
@@ -779,12 +779,12 @@ pub async fn handle_request(
                             if let Ok(target_information) =
                                 account_manager.find_target_information(cid, peer_cid).await
                             {
-                                let (peer_cid, mutual_peer) = target_information.unwrap();
+                                let (_, mutual_peer) = target_information.unwrap();
                                 match connect_after_register {
                                     true => {
                                         let connect_command = InternalServiceRequest::PeerConnect {
                                             cid,
-                                            peer_cid,
+                                            peer_cid: mutual_peer.cid.clone(),
                                             udp_mode: Default::default(),
                                             session_security_settings,
                                             request_id,
@@ -805,7 +805,7 @@ pub async fn handle_request(
                                             InternalServiceResponse::PeerRegisterSuccess(
                                                 PeerRegisterSuccess {
                                                     cid,
-                                                    peer_cid,
+                                                    peer_cid: mutual_peer.cid.clone(),
                                                     peer_username: mutual_peer
                                                         .username
                                                         .clone()

--- a/citadel-internal-service/tests/common/mod.rs
+++ b/citadel-internal-service/tests/common/mod.rs
@@ -23,6 +23,14 @@ use std::time::Duration;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use uuid::Uuid;
 
+pub fn setup_log() {
+    citadel_logging::setup_log();
+    std::panic::set_hook(Box::new(|info| {
+        citadel_logging::error!(target: "citadel", "Panic: {:?}", info);
+        std::process::exit(1);
+    }));
+}
+
 pub struct RegisterAndConnectItems<T: Into<String>, R: Into<String>, S: Into<SecBuffer>> {
     pub internal_service_addr: SocketAddr,
     pub server_addr: SocketAddr,

--- a/citadel-internal-service/tests/common/mod.rs
+++ b/citadel-internal-service/tests/common/mod.rs
@@ -262,7 +262,11 @@ pub async fn register_and_connect_to_server_then_peers(
                 .unwrap();
 
             // Receive Notification of Register Request
-            let _ = from_service_b.recv().await.unwrap();
+            let peer_register_notification = from_service_b.recv().await.unwrap();
+            assert!(matches!(
+                peer_register_notification,
+                InternalServiceResponse::PeerRegisterNotification(..)
+            ));
 
             info!(
                 target = "citadel",
@@ -333,7 +337,11 @@ pub async fn register_and_connect_to_server_then_peers(
                 .unwrap();
 
             // Receive Notification of Connect Request
-            let _ = from_service_b.recv().await.unwrap();
+            let peer_connect_notification = from_service_b.recv().await.unwrap();
+            assert!(matches!(
+                peer_connect_notification,
+                InternalServiceResponse::PeerConnectNotification(..)
+            ));
 
             info!(
                 target = "citadel",

--- a/citadel-internal-service/tests/common/mod.rs
+++ b/citadel-internal-service/tests/common/mod.rs
@@ -114,7 +114,10 @@ pub async fn register_and_connect_to_server<
             citadel_internal_service_types::RegisterSuccess { request_id: _ },
         ) = response_packet
         {
-            info!(target = "citadel", "RegisterSuccess Received, Now Connecting");
+            info!(
+                target = "citadel",
+                "RegisterSuccess Received, Now Connecting"
+            );
             // now, connect to the server
             let command = InternalServiceRequest::Connect {
                 username,
@@ -133,7 +136,10 @@ pub async fn register_and_connect_to_server<
                 citadel_internal_service_types::ConnectSuccess { cid, request_id: _ },
             ) = response_packet
             {
-                info!(target = "citadel", "ConnectSuccess Received, Creating Service Channels");
+                info!(
+                    target = "citadel",
+                    "ConnectSuccess Received, Creating Service Channels"
+                );
                 let (to_service, from_service) = tokio::sync::mpsc::unbounded_channel();
                 let service_to_test = async move {
                     // take messages from the service and send them to from_service
@@ -221,7 +227,10 @@ pub async fn register_and_connect_to_server_then_peers(
     // Registers and Connects all peers to Server
     let mut returned_service_info = register_and_connect_to_server(to_spawn).await.unwrap();
 
-    info!(target = "citadel", "Starting Registration and Connection between peers");
+    info!(
+        target = "citadel",
+        "Starting Registration and Connection between peers"
+    );
     // Registers and Connects all peers to Each Other Peer
     for service_index in 0..returned_service_info.len() {
         let (item, neighbor_items) = {
@@ -238,7 +247,10 @@ pub async fn register_and_connect_to_server_then_peers(
 
             // now, both peers are connected and registered to the central server. Now, we
             // need to have them peer-register to each other
-            info!(target = "citadel", "Peer {cid_a:?} Sending PeerRegister Request to {cid_b:?}");
+            info!(
+                target = "citadel",
+                "Peer {cid_a:?} Sending PeerRegister Request to {cid_b:?}"
+            );
             to_service_a
                 .send(InternalServiceRequest::PeerRegister {
                     request_id: Uuid::new_v4(),
@@ -252,7 +264,10 @@ pub async fn register_and_connect_to_server_then_peers(
             // Receive Notification of Register Request
             let _ = from_service_b.recv().await.unwrap();
 
-            info!(target = "citadel", "Peer {cid_b:?} Accepting PeerRegister Request From {cid_a:?}");
+            info!(
+                target = "citadel",
+                "Peer {cid_b:?} Accepting PeerRegister Request From {cid_a:?}"
+            );
             to_service_b
                 .send(InternalServiceRequest::PeerRegister {
                     request_id: Uuid::new_v4(),
@@ -271,7 +286,10 @@ pub async fn register_and_connect_to_server_then_peers(
                     peer_username: _,
                     request_id: _,
                 }) => {
-                    info!(target = "citadel", "Peer {cid_b:?} Received PeerRegisterSuccess Signal");
+                    info!(
+                        target = "citadel",
+                        "Peer {cid_b:?} Received PeerRegisterSuccess Signal"
+                    );
                     assert_eq!(cid, *cid_b);
                     assert_eq!(peer_cid, *cid_a);
                 }
@@ -288,7 +306,10 @@ pub async fn register_and_connect_to_server_then_peers(
                     peer_username: _,
                     request_id: _,
                 }) => {
-                    info!(target = "citadel", "Peer {cid_a:?} Received PeerRegisterSuccess Signal");
+                    info!(
+                        target = "citadel",
+                        "Peer {cid_a:?} Received PeerRegisterSuccess Signal"
+                    );
                     assert_eq!(cid, *cid_a);
                     assert_eq!(peer_cid, *cid_b);
                 }
@@ -297,7 +318,10 @@ pub async fn register_and_connect_to_server_then_peers(
                 }
             }
 
-            info!(target = "citadel", "Peer {cid_a:?} Sending PeerConnect Request to {cid_b:?}");
+            info!(
+                target = "citadel",
+                "Peer {cid_a:?} Sending PeerConnect Request to {cid_b:?}"
+            );
             to_service_a
                 .send(InternalServiceRequest::PeerConnect {
                     request_id: Uuid::new_v4(),
@@ -311,7 +335,10 @@ pub async fn register_and_connect_to_server_then_peers(
             // Receive Notification of Connect Request
             let _ = from_service_b.recv().await.unwrap();
 
-            info!(target = "citadel", "Peer {cid_b:?} Accepting PeerConnect Request From {cid_a:?}");
+            info!(
+                target = "citadel",
+                "Peer {cid_b:?} Accepting PeerConnect Request From {cid_a:?}"
+            );
             to_service_b
                 .send(InternalServiceRequest::PeerConnect {
                     request_id: Uuid::new_v4(),
@@ -328,7 +355,10 @@ pub async fn register_and_connect_to_server_then_peers(
                     cid,
                     request_id: _,
                 }) => {
-                    info!(target = "citadel", "Peer {cid_b:?} Received PeerConnectSuccess Signal");
+                    info!(
+                        target = "citadel",
+                        "Peer {cid_b:?} Received PeerConnectSuccess Signal"
+                    );
                     assert_eq!(cid, *cid_b);
                 }
                 _ => {
@@ -343,7 +373,10 @@ pub async fn register_and_connect_to_server_then_peers(
                     cid,
                     request_id: _,
                 }) => {
-                    info!(target = "citadel", "Peer {cid_a:?} Received PeerConnectSuccess Signal");
+                    info!(
+                        target = "citadel",
+                        "Peer {cid_a:?} Received PeerConnectSuccess Signal"
+                    );
                     assert_eq!(cid, *cid_a);
                 }
                 _ => {

--- a/citadel-internal-service/tests/common/mod.rs
+++ b/citadel-internal-service/tests/common/mod.rs
@@ -245,8 +245,10 @@ pub async fn register_and_connect_to_server_then_peers(
                 })
                 .unwrap();
 
-            let item = from_service_b.recv().await.unwrap();
+            // Receive Notification of Register Request
+            let _ = from_service_b.recv().await.unwrap();
 
+            let item = from_service_b.recv().await.unwrap();
             match item {
                 InternalServiceResponse::PeerRegisterSuccess(PeerRegisterSuccess {
                     cid,
@@ -297,6 +299,9 @@ pub async fn register_and_connect_to_server_then_peers(
                     session_security_settings,
                 })
                 .unwrap();
+
+            // Receive Notification of Connect Request
+            let _ = from_service_b.recv().await.unwrap();
 
             let item = from_service_b.recv().await.unwrap();
             match item {

--- a/citadel-internal-service/tests/file_transfer.rs
+++ b/citadel-internal-service/tests/file_transfer.rs
@@ -35,7 +35,7 @@ mod tests {
             exit(1);
         }));
 
-        citadel_logging::setup_log();
+        crate::common::setup_log();
         info!(target: "citadel", "above server spawn");
         let bind_address_internal_service: SocketAddr = "127.0.0.1:55518".parse().unwrap();
 
@@ -92,7 +92,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_internal_service_peer_standard_file_transfer() -> Result<(), Box<dyn Error>> {
-        citadel_logging::setup_log();
+        crate::common::setup_log();
         // internal service for peer A
         let bind_address_internal_service_a: SocketAddr = "127.0.0.1:55536".parse().unwrap();
         // internal service for peer B
@@ -181,7 +181,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_internal_service_c2s_revfs() -> Result<(), Box<dyn Error>> {
-        citadel_logging::setup_log();
+        crate::common::setup_log();
         info!(target: "citadel", "above server spawn");
         let bind_address_internal_service: SocketAddr = "127.0.0.1:55518".parse().unwrap();
 
@@ -302,7 +302,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_internal_service_peer_revfs() -> Result<(), Box<dyn Error>> {
-        citadel_logging::setup_log();
+        crate::common::setup_log();
         // internal service for peer A
         let bind_address_internal_service_a: SocketAddr = "127.0.0.1:55536".parse().unwrap();
         // internal service for peer B

--- a/citadel-internal-service/tests/group_chat.rs
+++ b/citadel-internal-service/tests/group_chat.rs
@@ -20,7 +20,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_internal_service_group_create() -> Result<(), Box<dyn Error>> {
-        citadel_logging::setup_log();
+        crate::common::setup_log();
         // internal service for peer A
         let bind_address_internal_service_a: SocketAddr = "127.0.0.1:55536".parse().unwrap();
         // internal service for peer B
@@ -166,7 +166,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_internal_service_group_invite() -> Result<(), Box<dyn Error>> {
-        citadel_logging::setup_log();
+        crate::common::setup_log();
         // internal service for peer A
         let bind_address_internal_service_a: SocketAddr = "127.0.0.1:55536".parse().unwrap();
         // internal service for peer B
@@ -335,7 +335,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_internal_service_group_request_join() -> Result<(), Box<dyn Error>> {
-        citadel_logging::setup_log();
+        crate::common::setup_log();
         // internal service for peer A
         let bind_address_internal_service_a: SocketAddr = "127.0.0.1:55536".parse().unwrap();
         // internal service for peer B
@@ -567,7 +567,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_internal_service_group_leave_and_end() -> Result<(), Box<dyn Error>> {
-        citadel_logging::setup_log();
+        crate::common::setup_log();
         // internal service for peer A
         let bind_address_internal_service_a: SocketAddr = "127.0.0.1:55536".parse().unwrap();
         // internal service for peer B
@@ -776,7 +776,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_internal_service_group_kick() -> Result<(), Box<dyn Error>> {
-        citadel_logging::setup_log();
+        crate::common::setup_log();
         // internal service for peer A
         let bind_address_internal_service_a: SocketAddr = "127.0.0.1:55536".parse().unwrap();
         // internal service for peer B
@@ -984,7 +984,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_internal_service_group_message() -> Result<(), Box<dyn Error>> {
-        citadel_logging::setup_log();
+        crate::common::setup_log();
         // internal service for peer A
         let bind_address_internal_service_a: SocketAddr = "127.0.0.1:55536".parse().unwrap();
         // internal service for peer B

--- a/citadel-internal-service/tests/group_chat.rs
+++ b/citadel-internal-service/tests/group_chat.rs
@@ -5,10 +5,11 @@ mod tests {
     use crate::common::*;
     use bytes::BytesMut;
     use citadel_internal_service_types::{
-        GroupCreateSuccess, GroupDisconnected, GroupEndSuccess, GroupEnded, GroupInvitation,
-        GroupInviteSuccess, GroupJoinRequestReceived, GroupKickFailure, GroupKickSuccess,
-        GroupLeaveSuccess, GroupLeft, GroupListGroupsForSuccess, GroupMemberStateChanged,
-        GroupMessageReceived, GroupMessageResponse, GroupMessageSuccess, GroupRequestDeclined,
+        GroupCreateSuccess, GroupDisconnectNotification, GroupEndNotification, GroupEndSuccess,
+        GroupInviteNotification, GroupInviteSuccess, GroupJoinRequestNotification,
+        GroupKickFailure, GroupKickSuccess, GroupLeaveNotification, GroupLeaveSuccess,
+        GroupListGroupsSuccess, GroupMemberStateChangeNotification, GroupMessageNotification,
+        GroupMessageResponse, GroupMessageSuccess, GroupRequestJoinDeclineResponse,
         GroupRequestJoinFailure, GroupRequestJoinSuccess, GroupRespondRequestFailure,
         GroupRespondRequestSuccess, InternalServiceRequest, InternalServiceResponse,
     };
@@ -64,7 +65,7 @@ mod tests {
             // Service B Declines Group Invitation
             let service_b_group_create_invite = from_service_b.recv().await.unwrap();
             info!(target: "citadel","Service B: {service_b_group_create_invite:?}");
-            if let InternalServiceResponse::GroupInvitation(GroupInvitation {
+            if let InternalServiceResponse::GroupInviteNotification(GroupInviteNotification {
                 cid: _,
                 peer_cid,
                 group_key,
@@ -113,7 +114,7 @@ mod tests {
             // Service C Accepts Group Invitation
             let service_c_group_create_invite = from_service_c.recv().await.unwrap();
             info!(target: "citadel","Service C: {service_c_group_create_invite:?}");
-            if let InternalServiceResponse::GroupInvitation(GroupInvitation {
+            if let InternalServiceResponse::GroupInviteNotification(GroupInviteNotification {
                 cid: _,
                 peer_cid,
                 group_key,
@@ -218,7 +219,7 @@ mod tests {
                 let service_b_group_inbound = from_service_b.recv().await.unwrap();
                 let owner_group_key = *group_key;
                 info!(target: "citadel","Service B: {service_b_group_inbound:?}");
-                if let InternalServiceResponse::GroupInvitation(GroupInvitation {
+                if let InternalServiceResponse::GroupInviteNotification(GroupInviteNotification {
                     cid: _,
                     peer_cid,
                     group_key,
@@ -281,7 +282,7 @@ mod tests {
                 let service_c_group_inbound = from_service_c.recv().await.unwrap();
                 let owner_group_key = *group_key;
                 info!(target: "citadel","Service C: {service_c_group_inbound:?}");
-                if let InternalServiceResponse::GroupInvitation(GroupInvitation {
+                if let InternalServiceResponse::GroupInviteNotification(GroupInviteNotification {
                     cid: _,
                     peer_cid,
                     group_key,
@@ -378,7 +379,7 @@ mod tests {
             to_service_b.send(service_b_group_outbound).unwrap();
             info!(target: "citadel","Service B Requesting Groups for Service A");
             let service_b_group_inbound = from_service_b.recv().await.unwrap();
-            if let InternalServiceResponse::GroupListGroupsForSuccess(GroupListGroupsForSuccess {
+            if let InternalServiceResponse::GroupListGroupsSuccess(GroupListGroupsSuccess {
                 cid: _,
                 peer_cid: _,
                 group_list,
@@ -418,8 +419,8 @@ mod tests {
                     }
 
                     let service_a_group_inbound = from_service_a.recv().await.unwrap();
-                    if let InternalServiceResponse::GroupJoinRequestReceived(
-                        GroupJoinRequestReceived {
+                    if let InternalServiceResponse::GroupJoinRequestNotification(
+                        GroupJoinRequestNotification {
                             cid: _,
                             peer_cid: _,
                             group_key,
@@ -443,8 +444,8 @@ mod tests {
                         info!(target: "citadel","Service A Accepted Join Request");
 
                         let service_b_group_inbound = from_service_b.recv().await.unwrap();
-                        if let InternalServiceResponse::GroupMemberStateChanged(
-                            GroupMemberStateChanged {
+                        if let InternalServiceResponse::GroupMemberStateChangeNotification(
+                            GroupMemberStateChangeNotification {
                                 cid: _,
                                 group_key: joined_group,
                                 state,
@@ -480,7 +481,7 @@ mod tests {
             to_service_c.send(service_c_group_outbound).unwrap();
             info!(target: "citadel","Service C Requesting Groups for Service A");
             let service_c_group_inbound = from_service_c.recv().await.unwrap();
-            if let InternalServiceResponse::GroupListGroupsForSuccess(GroupListGroupsForSuccess {
+            if let InternalServiceResponse::GroupListGroupsSuccess(GroupListGroupsSuccess {
                 cid: _,
                 peer_cid: _,
                 group_list,
@@ -520,8 +521,8 @@ mod tests {
                     }
 
                     let service_a_group_inbound = from_service_a.recv().await.unwrap();
-                    if let InternalServiceResponse::GroupJoinRequestReceived(
-                        GroupJoinRequestReceived {
+                    if let InternalServiceResponse::GroupJoinRequestNotification(
+                        GroupJoinRequestNotification {
                             cid: _,
                             peer_cid: _,
                             group_key,
@@ -541,8 +542,8 @@ mod tests {
                         to_service_a.send(service_a_group_outbound).unwrap();
                         info!(target: "citadel","Service A Declined Join Request");
                         let service_c_group_inbound = from_service_c.recv().await.unwrap();
-                        if let InternalServiceResponse::GroupRequestDeclined(
-                            GroupRequestDeclined { .. },
+                        if let InternalServiceResponse::GroupRequestJoinDeclineResponse(
+                            GroupRequestJoinDeclineResponse { .. },
                         ) = &service_c_group_inbound
                         {
                             info!(target: "citadel", "Service C Successfully Received Decline Response for Request Join");
@@ -611,7 +612,7 @@ mod tests {
             // Service B Accepts Invitation
             let service_b_group_create_invite = from_service_b.recv().await.unwrap();
             info!(target: "citadel","Service B: {service_b_group_create_invite:?}");
-            if let InternalServiceResponse::GroupInvitation(GroupInvitation {
+            if let InternalServiceResponse::GroupInviteNotification(GroupInviteNotification {
                 cid: _,
                 peer_cid,
                 group_key,
@@ -659,7 +660,7 @@ mod tests {
             // Service C Accepts Group Invitation
             let service_c_group_create_invite = from_service_c.recv().await.unwrap();
             info!(target: "citadel","Service C: {service_c_group_create_invite:?}");
-            if let InternalServiceResponse::GroupInvitation(GroupInvitation {
+            if let InternalServiceResponse::GroupInviteNotification(GroupInviteNotification {
                 cid: _,
                 peer_cid,
                 group_key,
@@ -720,7 +721,7 @@ mod tests {
                 panic!("Service C panicked while attempting to leave group");
             }
             let service_c_inbound = from_service_c.recv().await.unwrap();
-            if let InternalServiceResponse::GroupLeft(GroupLeft {
+            if let InternalServiceResponse::GroupLeaveNotification(GroupLeaveNotification {
                 cid: _,
                 group_key: _,
                 success,
@@ -751,7 +752,7 @@ mod tests {
                 &service_a_inbound
             {
                 let service_a_inbound = from_service_a.recv().await.unwrap();
-                if let InternalServiceResponse::GroupEnded(GroupEnded {
+                if let InternalServiceResponse::GroupEndNotification(GroupEndNotification {
                     cid: _,
                     group_key: ended_group,
                     success,
@@ -817,7 +818,9 @@ mod tests {
         {
             // Service B Accepts Invitation
             let service_b_group_create_invite = from_service_b.recv().await.unwrap();
-            if let InternalServiceResponse::GroupInvitation(..) = &service_b_group_create_invite {
+            if let InternalServiceResponse::GroupInviteNotification(..) =
+                &service_b_group_create_invite
+            {
                 let group_invite_response = InternalServiceRequest::GroupRespondRequest {
                     cid: cid_b,
                     peer_cid: cid_a,
@@ -843,7 +846,9 @@ mod tests {
 
             // Service C Accepts Group Invitation
             let service_c_group_create_invite = from_service_c.recv().await.unwrap();
-            if let InternalServiceResponse::GroupInvitation(..) = &service_c_group_create_invite {
+            if let InternalServiceResponse::GroupInviteNotification(..) =
+                &service_c_group_create_invite
+            {
                 let group_invite_response = InternalServiceRequest::GroupRespondRequest {
                     cid: cid_c,
                     peer_cid: cid_a,
@@ -932,20 +937,24 @@ mod tests {
             // Service B is notified that it was kicked
             let _ = from_service_b.recv().await.unwrap(); // MemberStateChanged from Service C Joining
             let service_b_inbound = from_service_b.recv().await.unwrap();
-            if let InternalServiceResponse::GroupDisconnected(GroupDisconnected {
-                cid: _,
-                group_key: disconnected_group,
-                request_id: _,
-            }) = &service_b_inbound
+            if let InternalServiceResponse::GroupDisconnectNotification(
+                GroupDisconnectNotification {
+                    cid: _,
+                    group_key: disconnected_group,
+                    request_id: _,
+                },
+            ) = &service_b_inbound
             {
                 assert_eq!(group_key, disconnected_group);
-            } else if let InternalServiceResponse::GroupLeft(GroupLeft {
-                cid: _,
-                group_key: group_left,
-                success: _,
-                message: _,
-                request_id: _,
-            }) = &service_b_inbound
+            } else if let InternalServiceResponse::GroupLeaveNotification(
+                GroupLeaveNotification {
+                    cid: _,
+                    group_key: group_left,
+                    success: _,
+                    message: _,
+                    request_id: _,
+                },
+            ) = &service_b_inbound
             {
                 assert_eq!(group_key, group_left);
             } else {
@@ -956,20 +965,24 @@ mod tests {
             let _ = from_service_c.recv().await.unwrap(); // MemberStateChanged from Service B getting kicked
             let _ = from_service_c.recv().await.unwrap(); // Extra MemberStateChanged Not Needed here
             let service_c_inbound = from_service_c.recv().await.unwrap();
-            if let InternalServiceResponse::GroupDisconnected(GroupDisconnected {
-                cid: _,
-                group_key: disconnected_group,
-                request_id: _,
-            }) = &service_c_inbound
+            if let InternalServiceResponse::GroupDisconnectNotification(
+                GroupDisconnectNotification {
+                    cid: _,
+                    group_key: disconnected_group,
+                    request_id: _,
+                },
+            ) = &service_c_inbound
             {
                 assert_eq!(group_key, disconnected_group);
-            } else if let InternalServiceResponse::GroupLeft(GroupLeft {
-                cid: _,
-                group_key: group_left,
-                success: _,
-                message: _,
-                request_id: _,
-            }) = &service_c_inbound
+            } else if let InternalServiceResponse::GroupLeaveNotification(
+                GroupLeaveNotification {
+                    cid: _,
+                    group_key: group_left,
+                    success: _,
+                    message: _,
+                    request_id: _,
+                },
+            ) = &service_c_inbound
             {
                 assert_eq!(group_key, group_left);
             } else {
@@ -1025,7 +1038,9 @@ mod tests {
         {
             // Service B Accepts Invitation
             let service_b_group_create_invite = from_service_b.recv().await.unwrap();
-            if let InternalServiceResponse::GroupInvitation(..) = &service_b_group_create_invite {
+            if let InternalServiceResponse::GroupInviteNotification(..) =
+                &service_b_group_create_invite
+            {
                 let group_invite_response = InternalServiceRequest::GroupRespondRequest {
                     cid: cid_b,
                     peer_cid: cid_a,
@@ -1051,7 +1066,9 @@ mod tests {
 
             // Service C Accepts Group Invitation
             let service_c_group_create_invite = from_service_c.recv().await.unwrap();
-            if let InternalServiceResponse::GroupInvitation(..) = &service_c_group_create_invite {
+            if let InternalServiceResponse::GroupInviteNotification(..) =
+                &service_c_group_create_invite
+            {
                 let group_invite_response = InternalServiceRequest::GroupRespondRequest {
                     cid: cid_c,
                     peer_cid: cid_a,
@@ -1098,13 +1115,15 @@ mod tests {
 
                 // All Services Receive Message
                 let service_b_inbound = from_service_b.recv().await.unwrap();
-                if let InternalServiceResponse::GroupMessageReceived(GroupMessageReceived {
-                    cid: _,
-                    peer_cid: _,
-                    message,
-                    group_key: _,
-                    request_id: _,
-                }) = &service_b_inbound
+                if let InternalServiceResponse::GroupMessageNotification(
+                    GroupMessageNotification {
+                        cid: _,
+                        peer_cid: _,
+                        message,
+                        group_key: _,
+                        request_id: _,
+                    },
+                ) = &service_b_inbound
                 {
                     info!(target: "citadel","Service B received message from Group A");
                     assert_eq!(*message, service_a_message.clone());
@@ -1112,13 +1131,15 @@ mod tests {
                     panic!("Service B Did Not Receive Message - instead received {service_b_inbound:?}");
                 }
                 let service_c_inbound = from_service_c.recv().await.unwrap();
-                if let InternalServiceResponse::GroupMessageReceived(GroupMessageReceived {
-                    cid: _,
-                    peer_cid: _,
-                    message,
-                    group_key: _,
-                    request_id: _,
-                }) = &service_c_inbound
+                if let InternalServiceResponse::GroupMessageNotification(
+                    GroupMessageNotification {
+                        cid: _,
+                        peer_cid: _,
+                        message,
+                        group_key: _,
+                        request_id: _,
+                    },
+                ) = &service_c_inbound
                 {
                     info!(target: "citadel","Service C received message from Group A");
                     assert_eq!(*message, service_a_message.clone());
@@ -1161,13 +1182,15 @@ mod tests {
 
                 // All Services Receive Message
                 let service_a_inbound = from_service_a.recv().await.unwrap();
-                if let InternalServiceResponse::GroupMessageReceived(GroupMessageReceived {
-                    cid: _,
-                    peer_cid: _,
-                    message,
-                    group_key: _,
-                    request_id: _,
-                }) = &service_a_inbound
+                if let InternalServiceResponse::GroupMessageNotification(
+                    GroupMessageNotification {
+                        cid: _,
+                        peer_cid: _,
+                        message,
+                        group_key: _,
+                        request_id: _,
+                    },
+                ) = &service_a_inbound
                 {
                     info!(target: "citadel","Service A received message from Service B in Group");
                     assert_eq!(*message, service_b_message.clone());
@@ -1175,13 +1198,15 @@ mod tests {
                     panic!("Service A Did Not Receive Message - instead received {service_a_inbound:?}");
                 }
                 let service_c_inbound = from_service_c.recv().await.unwrap();
-                if let InternalServiceResponse::GroupMessageReceived(GroupMessageReceived {
-                    cid: _,
-                    peer_cid: _,
-                    message,
-                    group_key: _,
-                    request_id: _,
-                }) = &service_c_inbound
+                if let InternalServiceResponse::GroupMessageNotification(
+                    GroupMessageNotification {
+                        cid: _,
+                        peer_cid: _,
+                        message,
+                        group_key: _,
+                        request_id: _,
+                    },
+                ) = &service_c_inbound
                 {
                     info!(target: "citadel","Service C received message from Service B in Group");
                     assert_eq!(*message, service_b_message.clone());

--- a/citadel-internal-service/tests/service.rs
+++ b/citadel-internal-service/tests/service.rs
@@ -11,7 +11,7 @@ mod tests {
     use citadel_internal_service_connector::util::InternalServiceConnector;
     use citadel_internal_service_types::{
         InternalServiceRequest, InternalServiceResponse, MessageReceived, MessageSent,
-        PeerConnectRequest, PeerRegisterRequest,
+        PeerConnectNotification, PeerRegisterNotification,
     };
     use citadel_logging::info;
     use citadel_sdk::prelude::*;
@@ -24,7 +24,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_internal_service_register_connect() -> Result<(), Box<dyn Error>> {
-        citadel_logging::setup_log();
+        crate::common::setup_log();
         info!(target: "citadel", "above server spawn");
         let bind_address_internal_service: SocketAddr = "127.0.0.1:55556".parse().unwrap();
 
@@ -80,7 +80,7 @@ mod tests {
     // test
     #[tokio::test]
     async fn message_test() -> Result<(), Box<dyn Error>> {
-        citadel_logging::setup_log();
+        crate::common::setup_log();
         info!(target: "citadel", "above server spawn");
         let bind_address_internal_service: SocketAddr = "127.0.0.1:55518".parse().unwrap();
 
@@ -179,7 +179,7 @@ mod tests {
 
     #[tokio::test]
     async fn connect_after_register_true() -> Result<(), Box<dyn Error>> {
-        citadel_logging::setup_log();
+        crate::common::setup_log();
         info!(target: "citadel", "above server spawn");
         let bind_address_internal_service: SocketAddr = "127.0.0.1:55568".parse().unwrap();
 
@@ -288,7 +288,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_internal_service_peer_test() -> Result<(), Box<dyn Error>> {
-        citadel_logging::setup_log();
+        crate::common::setup_log();
         let _ = register_and_connect_to_server_then_peers(vec![
             "127.0.0.1:55526".parse().unwrap(),
             "127.0.0.1:55527".parse().unwrap(),
@@ -299,7 +299,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_internal_service_peer_test_list_peers() -> Result<(), Box<dyn Error>> {
-        citadel_logging::setup_log();
+        crate::common::setup_log();
 
         let mut peer_return_handle_vec = register_and_connect_to_server_then_peers(vec![
             "127.0.0.1:55526".parse().unwrap(),
@@ -321,7 +321,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_internal_service_peer_message_test() -> Result<(), Box<dyn Error>> {
-        citadel_logging::setup_log();
+        crate::common::setup_log();
         // internal service for peer A
         let bind_address_internal_service_a: SocketAddr = "127.0.0.1:55536".parse().unwrap();
         // internal service for peer B
@@ -375,7 +375,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_c2s_kv() -> Result<(), Box<dyn Error>> {
-        citadel_logging::setup_log();
+        crate::common::setup_log();
         let (server, server_bind_address) = server_info_skip_cert_verification();
 
         let bind_address_internal_service_a: SocketAddr = "127.0.0.1:55537".parse().unwrap();
@@ -422,7 +422,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_p2p_kv() -> Result<(), Box<dyn Error>> {
-        citadel_logging::setup_log();
+        crate::common::setup_log();
         // internal service for peer A
         let bind_address_internal_service_a: SocketAddr = "127.0.0.1:55536".parse().unwrap();
         // internal service for peer B
@@ -445,7 +445,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_internal_service_forward_peer_requests() -> Result<(), Box<dyn Error>> {
-        citadel_logging::setup_log();
+        crate::common::setup_log();
         // TCP client (GUI, CLI) -> internal service -> empty kernel server(s)
         let (server, server_bind_address) = server_info_skip_cert_verification();
         tokio::task::spawn(server);
@@ -518,17 +518,19 @@ mod tests {
                 // Service B receives Register Request from Service A
                 let inbound_response = from_service_b.recv().await.unwrap();
                 match inbound_response {
-                    InternalServiceResponse::PeerRegisterRequest(PeerRegisterRequest {
-                        cid,
-                        peer_cid,
-                        peer_username: _,
-                        request_id: _,
-                    }) => {
+                    InternalServiceResponse::PeerRegisterNotification(
+                        PeerRegisterNotification {
+                            cid,
+                            peer_cid,
+                            peer_username: _,
+                            request_id: _,
+                        },
+                    ) => {
                         assert_eq!(cid, *cid_b);
                         assert_eq!(peer_cid, *cid_a);
                     }
                     _ => {
-                        panic!("Peer B didn't get the PeerRegisterRequest, instead got {inbound_response:?}");
+                        panic!("Peer B didn't get the PeerRegisterNotification, instead got {inbound_response:?}");
                     }
                 }
 
@@ -561,7 +563,7 @@ mod tests {
                 // Service B Receives Connect Request from Service A
                 let inbound_response = from_service_b.recv().await.unwrap();
                 match inbound_response {
-                    InternalServiceResponse::PeerConnectRequest(PeerConnectRequest {
+                    InternalServiceResponse::PeerConnectNotification(PeerConnectNotification {
                         cid,
                         peer_cid,
                         session_security_settings: _,
@@ -572,7 +574,7 @@ mod tests {
                         assert_eq!(peer_cid, *cid_a);
                     }
                     _ => {
-                        panic!("Peer B didn't get the PeerConnectRequest");
+                        panic!("Peer B didn't get the PeerConnectNotification");
                     }
                 }
 


### PR DESCRIPTION
Adds `PeerConnectRequest` and `PeerRegisterRequest` `InternalServiceResponse`s which are sent to the TCP client when receiving a Connect or Register request