### PR TITLE
`request_id ` attribute for generic response

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,9 @@ citadel-internal-service-connector = { path = "./citadel-internal-service-connec
 citadel-internal-service-macros = { path = "./citadel-internal-service-macros", default-features = false, version = "0.1.0" }
 
 # Avarok deps
-citadel_sdk = { git = "https://github.com/Avarok-Cybersecurity/Citadel-Protocol/" }
+citadel_sdk = { git = "https://github.com/Avarok-Cybersecurity/Citadel-Protocol/", branch = "utils-for-citadel-workspace"  }
 citadel_types = { git = "https://github.com/Avarok-Cybersecurity/Citadel-Protocol", branch = "utils-for-citadel-workspace" }
-citadel_logging = { git = "https://github.com/Avarok-Cybersecurity/Citadel-Protocol/" }
+citadel_logging = { git = "https://github.com/Avarok-Cybersecurity/Citadel-Protocol/", branch = "utils-for-citadel-workspace"  }
 
 # Standard deps
 serde = { version = "1.0.104", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ citadel-internal-service-macros = { path = "./citadel-internal-service-macros", 
 
 # Avarok deps
 citadel_sdk = { git = "https://github.com/Avarok-Cybersecurity/Citadel-Protocol/" }
-citadel_types = { git = "https://github.com/Avarok-Cybersecurity/Citadel-Protocol/" }
+citadel_types = { git = "https://github.com/Avarok-Cybersecurity/Citadel-Protocol", branch = "utils-for-citadel-workspace" }
 citadel_logging = { git = "https://github.com/Avarok-Cybersecurity/Citadel-Protocol/" }
 
 # Standard deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,7 @@ members = [
     "service",
 ]
 
-exclude = [
-    "./target/*"
-]
+exclude = ["./target/*"]
 
 [workspace.dependencies]
 
@@ -22,9 +20,9 @@ citadel-internal-service-connector = { path = "./citadel-internal-service-connec
 citadel-internal-service-macros = { path = "./citadel-internal-service-macros", default-features = false, version = "0.1.0" }
 
 # Avarok deps
-citadel_sdk = { git = "https://github.com/Avarok-Cybersecurity/Citadel-Protocol/"}
-citadel_types = { git = "https://github.com/Avarok-Cybersecurity/Citadel-Protocol"}
-citadel_logging = { git = "https://github.com/Avarok-Cybersecurity/Citadel-Protocol/"}
+citadel_sdk = { git = "https://github.com/Avarok-Cybersecurity/Citadel-Protocol/" }
+citadel_types = { git = "https://github.com/Avarok-Cybersecurity/Citadel-Protocol/" }
+citadel_logging = { git = "https://github.com/Avarok-Cybersecurity/Citadel-Protocol/" }
 
 # Standard deps
 serde = { version = "1.0.104", features = ["derive"] }
@@ -33,11 +31,11 @@ tokio-util = { version = "0.7.8", default-features = false }
 bincode2 = { version = "2.0.1", default-features = false }
 futures = { version = "0.3.28", default-features = false }
 bytes = { version = "1.4.0", default-features = false }
-uuid = { version="1.3.3", features = [
+uuid = { version = "1.3.3", features = [
     "v4",                # Lets you generate random UUIDs
     "fast-rng",          # Use a faster (but still sufficiently random) RNG
     "macro-diagnostics", # Enable better diagnostics for compile-time UUIDs
-]}
+] }
 anyhow = "1.0.71"
 async-recursion = { version = "1.0.4" }
 parking_lot = { version = "0.12.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,9 @@ citadel-internal-service-connector = { path = "./citadel-internal-service-connec
 citadel-internal-service-macros = { path = "./citadel-internal-service-macros", default-features = false, version = "0.1.0" }
 
 # Avarok deps
-citadel_sdk = { git = "https://github.com/Avarok-Cybersecurity/Citadel-Protocol/", branch = "utils-for-citadel-workspace"  }
-citadel_types = { git = "https://github.com/Avarok-Cybersecurity/Citadel-Protocol", branch = "utils-for-citadel-workspace" }
-citadel_logging = { git = "https://github.com/Avarok-Cybersecurity/Citadel-Protocol/", branch = "utils-for-citadel-workspace"  }
+citadel_sdk = { git = "https://github.com/Avarok-Cybersecurity/Citadel-Protocol/"}
+citadel_types = { git = "https://github.com/Avarok-Cybersecurity/Citadel-Protocol"}
+citadel_logging = { git = "https://github.com/Avarok-Cybersecurity/Citadel-Protocol/"}
 
 # Standard deps
 serde = { version = "1.0.104", features = ["derive"] }

--- a/citadel-internal-service-macros/src/lib.rs
+++ b/citadel-internal-service-macros/src/lib.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, Data, DataEnum, DeriveInput, Fields, Ident};
+use syn::{parse_macro_input, Data, DataEnum, DeriveInput, Ident};
 
 #[proc_macro_derive(IsError)]
 pub fn is_error_derive(input: TokenStream) -> TokenStream {
@@ -65,46 +65,4 @@ fn generate_match_arms(
             }
         })
         .collect()
-}
-
-
-
-#[proc_macro_derive(RequestId)]
-pub fn derive_request_id(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as DeriveInput);
-    let name = input.ident;
-
-    let request_id_impl = if let Data::Enum(data_enum) = &input.data {
-        let match_arms = data_enum.variants.iter().map(|variant| {
-            let variant_name = &variant.ident;
-            let request_id_field = if let Fields::Named(fields_named) = &variant.fields {
-                fields_named.named.iter().find(|field| field.ident.as_ref().unwrap() == "request_id")
-            } else {
-                None
-            };
-
-            if let Some(_) = request_id_field {
-                quote! {
-                    #name::#variant_name { ref request_id, .. } => *request_id,
-                }
-            } else {
-                quote! {}
-            }
-        });
-
-        quote! {
-            impl RequestId for #name {
-                fn request_id(&self) -> u32 {
-                    match self {
-                        #(#match_arms)*
-                        _ => panic!("Variant does not contain a request_id field"),
-                    }
-                }
-            }
-        }
-    } else {
-        quote! {}
-    };
-
-    TokenStream::from(request_id_impl)
 }

--- a/citadel-internal-service-macros/src/lib.rs
+++ b/citadel-internal-service-macros/src/lib.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, Data, DataEnum, DeriveInput, Ident};
+use syn::{parse_macro_input, Data, DataEnum, DeriveInput, Fields, Ident};
 
 #[proc_macro_derive(IsError)]
 pub fn is_error_derive(input: TokenStream) -> TokenStream {
@@ -65,4 +65,46 @@ fn generate_match_arms(
             }
         })
         .collect()
+}
+
+
+
+#[proc_macro_derive(RequestId)]
+pub fn derive_request_id(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = input.ident;
+
+    let request_id_impl = if let Data::Enum(data_enum) = &input.data {
+        let match_arms = data_enum.variants.iter().map(|variant| {
+            let variant_name = &variant.ident;
+            let request_id_field = if let Fields::Named(fields_named) = &variant.fields {
+                fields_named.named.iter().find(|field| field.ident.as_ref().unwrap() == "request_id")
+            } else {
+                None
+            };
+
+            if let Some(_) = request_id_field {
+                quote! {
+                    #name::#variant_name { ref request_id, .. } => *request_id,
+                }
+            } else {
+                quote! {}
+            }
+        });
+
+        quote! {
+            impl RequestId for #name {
+                fn request_id(&self) -> u32 {
+                    match self {
+                        #(#match_arms)*
+                        _ => panic!("Variant does not contain a request_id field"),
+                    }
+                }
+            }
+        }
+    } else {
+        quote! {}
+    };
+
+    TokenStream::from(request_id_impl)
 }

--- a/citadel-internal-service-types/src/lib.rs
+++ b/citadel-internal-service-types/src/lib.rs
@@ -1,5 +1,5 @@
 use bytes::BytesMut;
-use citadel_internal_service_macros::{IsError, IsNotification};
+use citadel_internal_service_macros::{IsError, IsNotification, RequestId};
 use citadel_sdk::prelude::PreSharedKey;
 pub use citadel_types::prelude::{
     ConnectMode, MemberState, MessageGroupKey, ObjectTransferStatus, SecBuffer, SecurityLevel,
@@ -565,7 +565,11 @@ pub struct FileTransferTickNotification {
     pub status: ObjectTransferStatus,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, IsError, IsNotification)]
+pub trait RequestId {
+    fn request_id(&self) -> u32;
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, IsError, IsNotification, RequestId)]
 pub enum InternalServiceResponse {
     ConnectSuccess(ConnectSuccess),
     ConnectFailure(ConnectFailure),

--- a/citadel-internal-service-types/src/lib.rs
+++ b/citadel-internal-service-types/src/lib.rs
@@ -38,7 +38,9 @@ pub struct RegisterFailure {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ServiceConnectionAccepted;
+pub struct ServiceConnectionAccepted {
+    pub request_id: Option<Uuid>,
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MessageSendSuccess {
@@ -546,6 +548,7 @@ pub struct FileTransferRequestNotification {
     pub cid: u64,
     pub peer_cid: u64,
     pub metadata: VirtualObjectMetadata,
+    pub request_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -563,6 +566,11 @@ pub struct FileTransferTickNotification {
     pub cid: u64,
     pub peer_cid: Option<u64>,
     pub status: ObjectTransferStatus,
+    pub request_id: Option<Uuid>,
+}
+
+pub trait ResponseId {
+    fn response_id() -> String;
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, IsError, IsNotification)]
@@ -644,6 +652,101 @@ pub enum InternalServiceResponse {
     ListAllPeersFailure(ListAllPeersFailure),
     ListRegisteredPeersResponse(ListRegisteredPeersResponse),
     ListRegisteredPeersFailure(ListRegisteredPeersFailure),
+}
+
+macro_rules! match_request_id {
+    ($val:expr, $($variant:ident),+) => {
+        match $val {
+            $(
+                InternalServiceResponse::$variant(x) => x.request_id,
+            )+
+        }
+    }
+}
+
+impl InternalServiceResponse {
+    pub fn request_id(&self) -> Option<Uuid> {
+        match_request_id!(
+            self,
+            ConnectSuccess,
+            ConnectFailure,
+            RegisterSuccess,
+            RegisterFailure,
+            ServiceConnectionAccepted,
+            MessageSendSuccess,
+            MessageSendFailure,
+            MessageNotification,
+            DisconnectNotification,
+            DisconnectFailure,
+            SendFileRequestSuccess,
+            SendFileRequestFailure,
+            FileTransferRequestNotification,
+            FileTransferStatusNotification,
+            FileTransferTickNotification,
+            DownloadFileSuccess,
+            DownloadFileFailure,
+            DeleteVirtualFileSuccess,
+            DeleteVirtualFileFailure,
+            PeerConnectSuccess,
+            PeerConnectFailure,
+            PeerConnectNotification,
+            PeerRegisterNotification,
+            PeerDisconnectSuccess,
+            PeerDisconnectFailure,
+            PeerRegisterSuccess,
+            PeerRegisterFailure,
+            GroupChannelCreateSuccess,
+            GroupChannelCreateFailure,
+            GroupBroadcastHandleFailure,
+            GroupCreateSuccess,
+            GroupCreateFailure,
+            GroupLeaveSuccess,
+            GroupLeaveFailure,
+            GroupLeaveNotification,
+            GroupEndSuccess,
+            GroupEndFailure,
+            GroupEndNotification,
+            GroupMessageNotification,
+            GroupMessageResponse,
+            GroupMessageSuccess,
+            GroupMessageFailure,
+            GroupInviteNotification,
+            GroupInviteSuccess,
+            GroupInviteFailure,
+            GroupRespondRequestSuccess,
+            GroupRespondRequestFailure,
+            GroupMembershipResponse,
+            GroupRequestJoinPendingNotification,
+            GroupDisconnectNotification,
+            GroupKickSuccess,
+            GroupKickFailure,
+            GroupListGroupsSuccess,
+            GroupListGroupsFailure,
+            GroupListGroupsResponse,
+            GroupJoinRequestNotification,
+            GroupRequestJoinAcceptResponse,
+            GroupRequestJoinDeclineResponse,
+            GroupRequestJoinSuccess,
+            GroupRequestJoinFailure,
+            GroupMemberStateChangeNotification,
+            LocalDBGetKVSuccess,
+            LocalDBGetKVFailure,
+            LocalDBSetKVSuccess,
+            LocalDBSetKVFailure,
+            LocalDBDeleteKVSuccess,
+            LocalDBDeleteKVFailure,
+            LocalDBGetAllKVSuccess,
+            LocalDBGetAllKVFailure,
+            LocalDBClearAllKVSuccess,
+            LocalDBClearAllKVFailure,
+            GetSessionsResponse,
+            GetAccountInformationResponse,
+            ListAllPeersResponse,
+            ListAllPeersFailure,
+            ListRegisteredPeersResponse,
+            ListRegisteredPeersFailure
+        )
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/citadel-internal-service-types/src/lib.rs
+++ b/citadel-internal-service-types/src/lib.rs
@@ -1,5 +1,5 @@
 use bytes::BytesMut;
-use citadel_internal_service_macros::{IsError, IsNotification, RequestId};
+use citadel_internal_service_macros::{IsError, IsNotification};
 use citadel_sdk::prelude::PreSharedKey;
 pub use citadel_types::prelude::{
     ConnectMode, MemberState, MessageGroupKey, ObjectTransferStatus, SecBuffer, SecurityLevel,
@@ -565,11 +565,7 @@ pub struct FileTransferTickNotification {
     pub status: ObjectTransferStatus,
 }
 
-pub trait RequestId {
-    fn request_id(&self) -> u32;
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, IsError, IsNotification, RequestId)]
+#[derive(Serialize, Deserialize, Debug, Clone, IsError, IsNotification)]
 pub enum InternalServiceResponse {
     ConnectSuccess(ConnectSuccess),
     ConnectFailure(ConnectFailure),

--- a/citadel-internal-service-types/src/lib.rs
+++ b/citadel-internal-service-types/src/lib.rs
@@ -661,6 +661,7 @@ pub enum InternalServiceResponse {
     ListRegisteredPeersFailure(ListRegisteredPeersFailure),
 }
 
+/// Shortcut for getting `.request_id` attribute on all members
 macro_rules! match_request_id {
     ($val:expr, $($variant:ident),+) => {
         match $val {

--- a/citadel-internal-service/src/kernel/ext.rs
+++ b/citadel-internal-service/src/kernel/ext.rs
@@ -27,7 +27,9 @@ pub trait IOInterfaceExt: IOInterface {
         tokio::task::spawn(async move {
             let write_task = async move {
                 let response =
-                    InternalServiceResponse::ServiceConnectionAccepted(ServiceConnectionAccepted);
+                    InternalServiceResponse::ServiceConnectionAccepted(ServiceConnectionAccepted {
+                        request_id: None,
+                    });
 
                 if let Err(err) = sink_send_payload::<Self>(response, &mut sink).await {
                     error!(target: "citadel", "Failed to send to client: {err:?}");

--- a/citadel-internal-service/src/kernel/mod.rs
+++ b/citadel-internal-service/src/kernel/mod.rs
@@ -368,6 +368,7 @@ fn spawn_tick_updater(
                                 cid: implicated_cid,
                                 peer_cid,
                                 status: status_message,
+                                request_id: None,
                             },
                         );
                         match entry.send(message.clone()) {

--- a/citadel-internal-service/src/kernel/responses/object_transfer_handle.rs
+++ b/citadel-internal-service/src/kernel/responses/object_transfer_handle.rs
@@ -53,6 +53,7 @@ pub async fn handle<T: IOInterface>(
                         cid: implicated_cid,
                         peer_cid,
                         metadata,
+                        request_id: None,
                     },
                 );
 


### PR DESCRIPTION
Depends on https://github.com/Avarok-Cybersecurity/Citadel-Protocol/pull/218

This allows us to use `.request_id` on any incoming response, which makes it much easier (and quicker) to access response ids from incoming messages.

Let me know if there is any way I can restructure this.